### PR TITLE
Skip pr.yaml test stages when ./tests directory is missing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -395,12 +395,18 @@ jobs:
 
       - name: Run tests with coverage (.NET Core 5.0 - 10.0)
         run: |
+          # Skip gracefully when there is no ./tests directory (e.g. template repos)
+          if [ ! -d "./tests" ]; then
+            echo "ℹ️  No ./tests directory found — skipping test execution"
+            exit 0
+          fi
+
           # Find all test projects (C#, VB.NET, F#)
           mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
-          
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            echo "ℹ️  No test projects found in ./tests directory — skipping test execution"
+            exit 0
           fi
           
           echo "=========================================="
@@ -660,12 +666,18 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
-          
+
+          # Skip gracefully when there is no ./tests directory (e.g. template repos)
+          if (-not (Test-Path './tests')) {
+            Write-Host "ℹ️  No ./tests directory found — skipping test execution"
+            exit 0
+          }
+
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' -ErrorAction SilentlyContinue)
+
           if (@($testProjects).Count -eq 0) {
-            Write-Error "❌ No test projects found in ./tests directory!"
-            exit 1
+            Write-Host "ℹ️  No test projects found in ./tests directory — skipping test execution"
+            exit 0
           }
           
           Write-Host "==========================================" -ForegroundColor Cyan
@@ -1015,15 +1027,21 @@ jobs:
 
       - name:  Run tests (.NET 6.0 - 10.0 only - ARM64 compatible)
         run: |
+          # Skip gracefully when there is no ./tests directory (e.g. template repos)
+          if [ ! -d "./tests" ]; then
+            echo "ℹ️  No ./tests directory found — skipping test execution"
+            exit 0
+          fi
+
           # Find all test projects (C#, VB.NET, F#)
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)          
-          
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            echo "ℹ️  No test projects found in ./tests directory — skipping test execution"
+            exit 0
           fi
           
           echo "=========================================="
@@ -1085,8 +1103,8 @@ jobs:
       - name: Enforce 90% coverage threshold
         run: |
           if [ ! -f "CoverageReport/Summary.txt" ]; then
-            echo "❌ Coverage report not generated!"
-            exit 1
+            echo "ℹ️  No coverage report generated — skipping threshold check"
+            exit 0
           fi
 
           echo "Coverage Summary:"


### PR DESCRIPTION
## Summary
- pr.yaml v3 test stages currently `exit 1` when `./tests` is absent. This template repo has no tests by design, so every PR (including #134, #135, #136, #137 from dependabot) fails on the test step even when build + security pass.
- Bring the workflow in line with `scripts/build-pr.ps1`, which already skips test execution gracefully (`No test projects found in ./tests — skipping`).

## Changes
- **Stage 1 (Linux)** — exit 0 with info message when `./tests` doesn't exist or contains no test projects.
- **Stage 2 (Windows / pwsh)** — same, plus added `-ErrorAction SilentlyContinue` to `Get-ChildItem`.
- **Stage 3 (macOS)** — same for the test step, and the **Enforce 90% coverage threshold** step now skips (instead of `exit 1`) when `Summary.txt` wasn't generated.
- Build, security scan, gitleaks, and detect-projects jobs are unchanged — they still run on every PR.

`release.yaml` and `scripts/build-pr.ps1` did not need updates (release.yaml doesn't reference `./tests`; build-pr.ps1 already had this behavior).

## Test plan
- [x] `pwsh ./scripts/build-pr.ps1 -SkipSecurity -SkipCoverage` succeeds locally and reports `No test projects found in ./tests - skipping` → `All checks passed`
- [x] YAML parses without errors
- [ ] Once merged, dependabot PRs #134–#137 should all pass on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)