### PR TITLE
Fix Windows stage restore for repos without root solution

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -656,11 +656,36 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore and build all projects
+        shell: pwsh
+        run: |
+          # Find solution file first, fall back to per-project restore
+          $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
 
-      - name: Build solution
-        run: dotnet build --no-restore --configuration Release
+          if ($solution) {
+            Write-Host "Found solution: $($solution.FullName)"
+            dotnet restore $solution.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            dotnet build $solution.FullName --no-restore --configuration Release
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } else {
+            Write-Host "No solution file found, restoring and building projects individually..."
+            $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
+            if (-not $projects) {
+              $projects = Get-ChildItem -Path . -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
+            }
+
+            foreach ($proj in $projects) {
+              Write-Host "Restoring $($proj.Name)"
+              dotnet restore $proj.FullName
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              Write-Host "Building $($proj.Name)"
+              dotnet build $proj.FullName --no-restore --configuration Release
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            }
+          }
+
+          Write-Host "✅ All projects built successfully"
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh


### PR DESCRIPTION
## Summary
- Stage 2 (Windows) did bare `dotnet restore`/`dotnet build` at root, which fails because this repo has no solution file at root
- Now discovers solution files recursively, or falls back to per-project restore/build
- Also updated branch ruleset required status checks to match current workflow job names

## Test plan
- [ ] Verify all PR check stages pass
- [ ] Verify PR #134 (dependabot Meziantou bump) can be unblocked after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)