### PR TITLE
Fix stale exit code in pr.yaml config fetch step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -194,6 +194,9 @@ jobs:
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
+          # Reset exit code — git cat-file -e leaves $LASTEXITCODE=1 for missing files
+          exit 0
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Summary
The PowerShell config fetch step fails with exit code 1 because `git cat-file -e` for missing files (Directory.Build.props, BannedSymbols.txt) sets `$LASTEXITCODE=1`. PowerShell propagates this as the script's exit code even though the script handled it correctly.

Adds `exit 0` at the end of the step.

This is blocking all PRs (#134, #135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)