### PR TITLE
Bump template package versions to 0.5.0

### DIFF
--- a/src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj
+++ b/src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console</PackageId>
     <Title>Wolfgang Console App</Title>
     <Authors>Chris Wolfgang</Authors>

--- a/src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj
+++ b/src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console.ETL-SubCommand</PackageId>
     <Title>Wolfgang Console ETL Subcommand</Title>
     <Authors>Chris Wolfgang</Authors>

--- a/src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj
+++ b/src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console.Subcommand</PackageId>
     <Title>Wolfgang Console Subcommand</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
## Summary
- Bumps `PackageVersion` from 0.4.0 to 0.5.0 on all three templates so they release in lockstep:
  - `Wolfgang.Template.Console`
  - `Wolfgang.Template.Console.Subcommand`
  - `Wolfgang.Template.Console.ETL-SubCommand`

## Test plan
- [ ] CI builds and packs all three templates