### PR TITLE
Sync remaining template drift (.editorconfig, pr.yaml, docfx.yaml, coverlet.runsettings)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,10 +26,12 @@ indent_size = 2
 indent_size = 2
 
 # PowerShell files
-# LF line endings for cross-platform shebang compatibility, aligned with .gitattributes
+# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
+# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
 [*.ps1]
 indent_size = 4
-end_of_line = lf
+end_of_line = crlf
+charset = utf-8-bom
 
 # C# files
 [*.cs]
@@ -37,13 +39,19 @@ end_of_line = lf
 # SA0001 - Disable XML documentation file requirement
 dotnet_diagnostic.SA0001.severity = none
 
+# .NET Code Analysis Rules
+# Enable .NET analyzers with conservative defaults
+dotnet_analyzer_diagnostic.severity = suggestion
+
 # IDE (Code Style) Rules
 dotnet_diagnostic.IDE0005.severity = suggestion   # Remove unnecessary usings
 # Allow var usage - modern C# style
 dotnet_diagnostic.IDE0007.severity = none        # Use var instead of explicit type
 dotnet_diagnostic.IDE0008.severity = none        # Use explicit type instead of var
+# Prefer expression bodies - suppress the suggestion to use block bodies instead
+dotnet_diagnostic.IDE0022.severity = none        # Expression bodies preferred
 
-# CA (Code Analysis) Rules
+# CA (Code Analysis) Rules - Set defaults
 dotnet_diagnostic.CA1000.severity = warning
 dotnet_diagnostic.CA1001.severity = warning
 dotnet_diagnostic.CA1010.severity = warning
@@ -51,14 +59,31 @@ dotnet_diagnostic.CA1016.severity = warning
 dotnet_diagnostic.CA1063.severity = warning
 dotnet_diagnostic.CA1849.severity = warning       # Call async methods when in async method
 
-# AsyncFixer Rules
+# AsyncFixer Rules (all 5 rules explicitly configured)
 dotnet_diagnostic.AsyncFixer01.severity = error   # Unnecessary async/await
 dotnet_diagnostic.AsyncFixer02.severity = error   # Blocking synchronous operations inside async methods
 dotnet_diagnostic.AsyncFixer03.severity = warning # Fire-and-forget async void
 dotnet_diagnostic.AsyncFixer04.severity = error   # Fire-and-forget async call inside using block
 dotnet_diagnostic.AsyncFixer05.severity = suggestion # Downcasting from Task<T> to Task
 
-# Roslynator Rules
+# VSTHRD (Visual Studio Threading) Rules - Common rules explicitly configured
+dotnet_diagnostic.VSTHRD100.severity = warning    # Avoid async void methods
+dotnet_diagnostic.VSTHRD101.severity = warning    # Avoid unsupported async delegates
+dotnet_diagnostic.VSTHRD102.severity = warning    # Implement internal logic asynchronously
+dotnet_diagnostic.VSTHRD103.severity = warning    # Call async methods when in async method
+dotnet_diagnostic.VSTHRD104.severity = warning    # Offer async option
+dotnet_diagnostic.VSTHRD105.severity = warning    # Avoid method overloads that assume TaskScheduler.Current
+dotnet_diagnostic.VSTHRD106.severity = warning    # Use InvokeAsync to raise async events
+dotnet_diagnostic.VSTHRD107.severity = warning    # Await Task within using expression
+dotnet_diagnostic.VSTHRD108.severity = warning    # Assert thread affinity unconditionally
+dotnet_diagnostic.VSTHRD109.severity = warning    # Switch instead of assert in async methods
+dotnet_diagnostic.VSTHRD110.severity = warning    # Observe result of async calls
+dotnet_diagnostic.VSTHRD111.severity = none       # ConfigureAwait - not needed in library code targeting modern .NET
+dotnet_diagnostic.VSTHRD112.severity = warning    # Implement System.IAsyncDisposable
+dotnet_diagnostic.VSTHRD114.severity = warning    # Avoid returning null from a Task-returning method
+dotnet_diagnostic.VSTHRD200.severity = suggestion # Use Async naming convention
+
+# Roslynator Rules - Common rules explicitly configured
 dotnet_diagnostic.RCS1001.severity = suggestion   # Add braces
 dotnet_diagnostic.RCS1036.severity = none         # Remove unnecessary blank line
 dotnet_diagnostic.RCS1037.severity = suggestion   # Remove trailing white-space
@@ -67,6 +92,10 @@ dotnet_diagnostic.RCS1140.severity = warning      # Add exception to documentati
 dotnet_diagnostic.RCS1141.severity = suggestion   # Add parameter to documentation comment
 dotnet_diagnostic.RCS1163.severity = warning      # Unused parameter
 dotnet_diagnostic.RCS1175.severity = suggestion   # Unused this parameter
+dotnet_diagnostic.RCS1180.severity = suggestion   # Inline lazy initialization
+dotnet_diagnostic.RCS1181.severity = suggestion   # Convert comment to documentation comment
+dotnet_diagnostic.RCS1186.severity = suggestion   # Use Regex instance instead of static method
+dotnet_diagnostic.RCS1197.severity = suggestion   # Optimize StringBuilder.Append/AppendLine call
 dotnet_diagnostic.RCS1214.severity = suggestion   # Unnecessary interpolated string
 dotnet_diagnostic.RCS1227.severity = suggestion   # Validate arguments correctly
 
@@ -76,30 +105,97 @@ dotnet_diagnostic.MA0002.severity = suggestion   # IEqualityComparer<string> mis
 dotnet_diagnostic.MA0003.severity = warning      # Add parameter name to improve readability
 dotnet_diagnostic.MA0004.severity = suggestion   # Use Task.ConfigureAwait(false)
 dotnet_diagnostic.MA0006.severity = warning      # Use String.Equals instead of equality operator
+dotnet_diagnostic.MA0007.severity = suggestion   # Add comma after the last value
 dotnet_diagnostic.MA0011.severity = suggestion   # IFormatProvider is missing
+dotnet_diagnostic.MA0016.severity = suggestion   # Prefer returning collection abstraction instead of implementation
 dotnet_diagnostic.MA0025.severity = warning      # Implement the functionality instead of throwing NotImplementedException
 dotnet_diagnostic.MA0026.severity = suggestion   # Fix TODO comment
+dotnet_diagnostic.MA0028.severity = warning      # Optimize StringBuilder usage
+dotnet_diagnostic.MA0029.severity = warning      # Combine LINQ methods
 dotnet_diagnostic.MA0036.severity = suggestion   # Make class static
 dotnet_diagnostic.MA0038.severity = suggestion   # Make method static
 dotnet_diagnostic.MA0040.severity = warning      # Flow the cancellation token
 dotnet_diagnostic.MA0048.severity = warning      # File name must match type name
 dotnet_diagnostic.MA0051.severity = warning      # Method is too long
 dotnet_diagnostic.MA0053.severity = suggestion   # Make class sealed
-dotnet_diagnostic.MA0076.severity = suggestion   # Do not use implicit culture-sensitive ToString
+dotnet_diagnostic.MA0056.severity = suggestion   # Do not call overridable members in constructor
+dotnet_diagnostic.MA0073.severity = suggestion   # Avoid comparison with bool constant
+dotnet_diagnostic.MA0076.severity = suggestion   # Do not use implicit culture-sensitive ToString in interpolated strings
 
 # SonarAnalyzer Rules
 dotnet_diagnostic.S1118.severity = suggestion    # Utility classes should not have public constructors
-dotnet_diagnostic.S1135.severity = none          # (Disabled: overlaps with MA0026)
+dotnet_diagnostic.S1135.severity = none          # (Disabled: overlaps with MA0026 "Fix TODO comment")
 dotnet_diagnostic.S1199.severity = warning       # Nested code blocks should not be used
+dotnet_diagnostic.S2223.severity = warning       # Non-constant static fields should not be visible
 dotnet_diagnostic.S2259.severity = warning       # Null pointers should not be dereferenced
 dotnet_diagnostic.S2583.severity = warning       # Conditionally executed code should be reachable
 dotnet_diagnostic.S2589.severity = warning       # Boolean expressions should not be gratuitous
-dotnet_diagnostic.S2933.severity = warning       # Fields that are only assigned in constructor should be readonly
+dotnet_diagnostic.S2696.severity = suggestion    # Instance members should not write to "static" fields
+dotnet_diagnostic.S2933.severity = warning       # Fields that are only assigned in the constructor should be "readonly"
+dotnet_diagnostic.S2934.severity = warning       # Property assignments should not be made for "readonly" fields
+dotnet_diagnostic.S3215.severity = suggestion    # "interface" instances should not be cast to concrete types
+dotnet_diagnostic.S3216.severity = suggestion    # "ConfigureAwait(false)" should be used in library code (especially for .NET Framework 4.6.2 / .NET Standard 2.0 targets)
+dotnet_diagnostic.S3218.severity = suggestion    # Inner class members should not shadow outer class "static" or type members
+dotnet_diagnostic.S3236.severity = warning       # Caller information arguments should not be provided explicitly
+dotnet_diagnostic.S3242.severity = suggestion    # Method parameters should be declared with base types
+dotnet_diagnostic.S3247.severity = warning       # Duplicate casts should not be made
+dotnet_diagnostic.S3253.severity = suggestion    # Constructor and destructor declarations should not be redundant
 dotnet_diagnostic.S3257.severity = warning       # Declarations and initializations should be as concise as possible
 dotnet_diagnostic.S3358.severity = warning       # Ternary operators should not be nested
-dotnet_diagnostic.S3776.severity = suggestion    # Cognitive Complexity should not be too high
-dotnet_diagnostic.S3881.severity = warning       # IDisposable should be implemented correctly
+dotnet_diagnostic.S3400.severity = warning       # Methods should not return constants
+dotnet_diagnostic.S3441.severity = warning       # Redundant property names should be omitted in anonymous classes
+dotnet_diagnostic.S3442.severity = warning       # "abstract" classes should not have "public" constructors
+dotnet_diagnostic.S3443.severity = warning       # Type should not be examined on "System.Type" instances
+dotnet_diagnostic.S3449.severity = suggestion    # Right operands of shift operators should be integers
+dotnet_diagnostic.S3451.severity = warning       # Classes should not have only "private" constructors
+dotnet_diagnostic.S3604.severity = warning       # Member initializer values should not be redundant
+dotnet_diagnostic.S3776.severity = suggestion    # Cognitive Complexity of methods should not be too high
+dotnet_diagnostic.S3881.severity = warning       # "IDisposable" should be implemented correctly
+dotnet_diagnostic.S3897.severity = suggestion    # Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+dotnet_diagnostic.S3898.severity = warning       # Value types should implement "IEquatable<T>"
+dotnet_diagnostic.S3902.severity = warning       # "Assembly.GetExecutingAssembly" should not be called
+dotnet_diagnostic.S3903.severity = warning       # Types should be defined in named namespaces
+dotnet_diagnostic.S3904.severity = warning       # Assemblies should have version information
+dotnet_diagnostic.S3925.severity = warning       # "ISerializable" should be implemented correctly
+dotnet_diagnostic.S3926.severity = warning       # Deserialization methods should be provided for "OptionalField" members
+dotnet_diagnostic.S3927.severity = warning       # Serialization event handlers should be implemented correctly
+dotnet_diagnostic.S4049.severity = suggestion    # Properties should be preferred
+dotnet_diagnostic.S4056.severity = suggestion    # Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 dotnet_diagnostic.S4136.severity = warning       # Method overloads should be grouped together
+
+# SecurityCodeScan Rules
+dotnet_diagnostic.SCS0005.severity = warning     # Weak random number generator
+dotnet_diagnostic.SCS0006.severity = warning     # Weak hash algorithm
+dotnet_diagnostic.SCS0015.severity = warning     # Hardcoded password
+dotnet_diagnostic.SCS0016.severity = warning     # Controller method is vulnerable to CSRF
+dotnet_diagnostic.SCS0017.severity = warning     # Request validation disabled
+dotnet_diagnostic.SCS0018.severity = warning     # Path traversal
+dotnet_diagnostic.SCS0019.severity = warning     # OutputCache conflict
+dotnet_diagnostic.SCS0020.severity = warning     # SQL injection via EF raw query
+dotnet_diagnostic.SCS0026.severity = warning     # SQL injection via EF FromSqlRaw
+dotnet_diagnostic.SCS0029.severity = warning     # Cross-Site Scripting (XSS)
+dotnet_diagnostic.SCS0031.severity = warning     # SQL injection via EF ExecuteSqlRaw
+
+# Performance-critical rules for library code
+dotnet_diagnostic.CA1062.severity = warning       # Validate arguments of public methods
+dotnet_diagnostic.CA1508.severity = warning       # Avoid dead conditional code
+dotnet_diagnostic.CA1510.severity = none          # Disabled for multi-targeting: recommends ArgumentNullException.ThrowIfNull (not available on net462/netstandard2.0)
+dotnet_diagnostic.CA1810.severity = warning       # Initialize static fields inline
+dotnet_diagnostic.CA1822.severity = suggestion    # Mark members as static
+dotnet_diagnostic.CA1825.severity = warning       # Avoid zero-length array allocations
+dotnet_diagnostic.CA1826.severity = warning       # Use property instead of Linq Enumerable method
+dotnet_diagnostic.CA1827.severity = warning       # Do not use Count/LongCount when Any can be used
+dotnet_diagnostic.CA1828.severity = warning       # Do not use CountAsync/LongCountAsync when AnyAsync can be used
+dotnet_diagnostic.CA1829.severity = warning       # Use Length/Count property instead of Enumerable.Count method
+dotnet_diagnostic.CA1851.severity = warning       # Possible multiple enumerations of IEnumerable collection
+
+# Async/IAsyncEnumerable specific rules (CRITICAL for this library)
+dotnet_diagnostic.CA2007.severity = warning       # ConfigureAwait - enforce usage in library async code
+dotnet_diagnostic.CA2012.severity = error         # Use ValueTasks correctly
+dotnet_diagnostic.CA2016.severity = warning       # Forward CancellationToken parameter
+
+# Banned API Analyzer (RS0030) - Enforce async-first best practices
+dotnet_diagnostic.RS0030.severity = error         # Using banned API - treat as error
 
 # New line preferences
 csharp_new_line_before_open_brace = all
@@ -183,10 +279,11 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 
 # Wrapping preferences
+# Preserve manual line breaks and allow flexible parameter formatting
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Line length guidance
+# Line length guidance (not enforced by dotnet format, but used by some IDEs)
 csharp_max_line_length = 120
 
 # Naming conventions
@@ -243,3 +340,146 @@ dotnet_diagnostic.SA1101.severity = none
 dotnet_diagnostic.SA1300.severity = error
 dotnet_diagnostic.IDE1006.severity = error
 dotnet_diagnostic.CA1707.severity = error
+
+# Source code - strict rules
+[src/**/*.cs]
+# Documentation required
+dotnet_diagnostic.SA1600.severity = warning
+dotnet_diagnostic.SA1601.severity = warning
+dotnet_diagnostic.SA1602.severity = warning
+
+# Library code should preserve synchronization context by default
+# Consumers decide whether to use ConfigureAwait(false) when calling library methods
+dotnet_diagnostic.MA0004.severity = none     # Meziantou: Use ConfigureAwait
+dotnet_diagnostic.S3216.severity = none      # SonarAnalyzer: ConfigureAwait
+dotnet_diagnostic.CA2007.severity = none     # .NET Analyzer: Use ConfigureAwait
+
+# Test projects - relaxed naming, no doc requirements
+[tests/**/*.cs]
+# Allow Test_Method_Names_With_Underscores
+dotnet_diagnostic.SA1300.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.CA1707.severity = none
+
+# Allow synchronous CancellationTokenSource.Cancel() in tests
+dotnet_diagnostic.CA1849.severity = none
+
+# Relax async/await analyzer rules for tests
+dotnet_diagnostic.AsyncFixer01.severity = none    # Allow unnecessary async/await in tests
+dotnet_diagnostic.AsyncFixer02.severity = none    # Allow synchronous blocking in tests
+dotnet_diagnostic.AsyncFixer05.severity = none    # Allow downcasting in tests
+dotnet_diagnostic.IDE0058.severity = none          # Allow unused expression values in tests
+dotnet_diagnostic.VSTHRD102.severity = none       # Allow synchronous implementation in tests
+dotnet_diagnostic.VSTHRD103.severity = none       # Allow calling sync methods when async alternatives exist in tests
+dotnet_diagnostic.VSTHRD104.severity = none       # Allow missing async options in tests
+dotnet_diagnostic.VSTHRD107.severity = none       # Allow Task in using without await in tests
+dotnet_diagnostic.VSTHRD114.severity = none       # Allow returning null from Task methods in tests
+dotnet_diagnostic.VSTHRD200.severity = none       # Async suffix not required in test method names
+
+# Banned API Analyzer - Allow in tests (sync I/O and Stream overrides are common in test setup)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in tests
+
+# Meziantou - Relax in tests
+dotnet_diagnostic.MA0004.severity = none         # ConfigureAwait not needed in tests
+dotnet_diagnostic.MA0011.severity = none         # IFormatProvider not critical in tests
+dotnet_diagnostic.MA0026.severity = none         # TODO comments OK in tests
+dotnet_diagnostic.MA0040.severity = none         # CancellationToken flow not critical in tests
+dotnet_diagnostic.MA0048.severity = none         # File name matching not critical in tests
+dotnet_diagnostic.MA0051.severity = none         # Method length OK in tests
+
+# SonarAnalyzer - Relax in tests
+dotnet_diagnostic.S1118.severity = none          # Utility class constructors OK in tests
+dotnet_diagnostic.S1135.severity = none          # TODO tags OK in tests
+dotnet_diagnostic.S1144.severity = none          # Unused private members OK in tests (reflection-based POCOs)
+dotnet_diagnostic.S3216.severity = none          # ConfigureAwait not needed in tests
+dotnet_diagnostic.S3776.severity = none          # Complexity OK in tests
+dotnet_diagnostic.S4049.severity = none          # Properties vs methods flexibility in tests
+dotnet_diagnostic.S6966.severity = none          # Async versions not available on all target frameworks
+
+# .NET Analyzer - Relax in tests
+dotnet_diagnostic.CA2007.severity = none         # ConfigureAwait not needed in tests
+
+# SecurityCodeScan - Relax in tests (but keep serious ones)
+dotnet_diagnostic.SCS0005.severity = suggestion  # Weak random OK for test data
+
+# No documentation required for tests
+dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1602.severity = none
+
+# Benchmark projects - relaxed naming, no doc requirements
+[benchmarks/**/*.cs]
+# Allow Benchmark_Method_Names
+dotnet_diagnostic.SA1300.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.CA1707.severity = none
+
+# Relax async/await analyzer rules for benchmarks
+dotnet_diagnostic.AsyncFixer01.severity = none    # Allow unnecessary async/await in benchmarks
+
+# ConfigureAwait not needed in benchmarks
+dotnet_diagnostic.MA0004.severity = none          # Meziantou: Use ConfigureAwait
+dotnet_diagnostic.S3216.severity = none           # SonarAnalyzer: ConfigureAwait
+dotnet_diagnostic.CA2007.severity = none          # .NET Analyzer: Use ConfigureAwait
+
+# Banned API Analyzer - Allow in benchmarks (sync APIs are often the benchmark target)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in benchmarks
+
+# No documentation required for benchmarks
+dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1602.severity = none
+
+# Suppress Meziantou, Sonar, and VSTHRD analyzers in benchmarks
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0016.severity = none
+dotnet_diagnostic.MA0021.severity = none
+dotnet_diagnostic.MA0036.severity = none
+dotnet_diagnostic.MA0038.severity = none
+dotnet_diagnostic.MA0040.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.MA0051.severity = none
+dotnet_diagnostic.MA0053.severity = none
+dotnet_diagnostic.MA0076.severity = none
+dotnet_diagnostic.S1118.severity = none
+dotnet_diagnostic.S1144.severity = none
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S6966.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Example projects - relaxed naming, docs encouraged
+[examples/**/*.cs]
+# Allow Example_Method_Names
+dotnet_diagnostic.SA1300.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.CA1707.severity = none
+
+# Documentation helpful but not required
+dotnet_diagnostic.SA1600.severity = suggestion
+dotnet_diagnostic.SA1601.severity = suggestion
+dotnet_diagnostic.SA1602.severity = suggestion
+
+# Banned API Analyzer - Allow in examples for demonstration purposes
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in examples for demonstration
+
+# Suppress Meziantou, Sonar, and VSTHRD analyzers in examples
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0004.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0016.severity = none
+dotnet_diagnostic.MA0021.severity = none
+dotnet_diagnostic.MA0036.severity = none
+dotnet_diagnostic.MA0038.severity = none
+dotnet_diagnostic.MA0040.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.MA0051.severity = none
+dotnet_diagnostic.MA0053.severity = none
+dotnet_diagnostic.MA0076.severity = none
+dotnet_diagnostic.S1118.severity = none
+dotnet_diagnostic.S1144.severity = none
+dotnet_diagnostic.S3216.severity = none
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S6966.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -2,7 +2,7 @@ name: Deploy DocFX Pages
 
 on:
   # Called by release.yaml after a GitHub Release is published.
-  # Callers may pass an explicit 'version' string (e.g. v1.0.0); when omitted,
+  # Callers may pass an explicit 'version' string (e.g. v1.2.3); when omitted,
   # the destination directory is derived from github.ref_name automatically.
   workflow_call:
     inputs:
@@ -60,66 +60,57 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
             8.0.x
             9.0.x
             10.0.x
 
-      - name: Restore and build all projects
+      - name: Restore dependencies
+        run: dotnet restore
         shell: pwsh
-        run: |
-          $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj'
 
-          foreach ($proj in $projects) {
-            dotnet restore $proj.FullName
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-            dotnet build $proj.FullName --no-restore --configuration Release
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          }
-
-      - name: Check for DocFX configuration
-        id: check-docfx
+      - name: Build solution
+        run: dotnet build --configuration Release --no-restore
         shell: pwsh
-        run: |
-          if (Test-Path "docfx_project/docfx.json") {
-            Write-Host "✅ DocFX configuration found"
-            "has-docfx=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          } else {
-            Write-Host "ℹ️ No docfx.json found in docfx_project/ — skipping documentation build"
-            "has-docfx=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          }
 
       - name: Install DocFX
-        if: steps.check-docfx.outputs.has-docfx == 'true'
         run: dotnet tool update docfx --global || dotnet tool install docfx --global
         shell: pwsh
 
       - name: Build DocFX Metadata
-        if: steps.check-docfx.outputs.has-docfx == 'true'
         run: docfx metadata
         working-directory: docfx_project
         shell: pwsh
 
       - name: Build Docs
-        if: steps.check-docfx.outputs.has-docfx == 'true'
         run: docfx build
         working-directory: docfx_project
         shell: pwsh
 
       - name: Verify build output
-        if: steps.check-docfx.outputs.has-docfx == 'true'
         run: |
           if (-Not (Test-Path "docfx_project/_site")) {
           Write-Host "Error: docfx_project/_site directory not found!"
           exit 1
-          }
-          Write-Host "Build successful. Contents of _site:"
+          }  
+          Write-Host "Build successful. Contents of _site:" 
           Get-ChildItem "docfx_project/_site"
           Write-Host "API documentation:"
           Get-ChildItem "docfx_project/_site/api"
         shell: pwsh
 
       - name: Generate versions.json
-        if: steps.check-docfx.outputs.has-docfx == 'true'
+        # Produces versions.json consumed by the DocFX version-switcher dropdown.
+        # Site layout:
+        #   /<repo>/               ← version-picker index.html (deployed to root)
+        #   /<repo>/versions/latest/  ← latest docs (alias under versions/)
+        #   /<repo>/versions/v1.2.3/  ← versioned docs (under versions/)
+        # versions.json format expected by the dropdown:
+        #   [{ "version": "latest", "url": "/<repo>/versions/latest/" }, { "version": "v1.2.3", "url": "/<repo>/versions/v1.2.3/" }]
+        # URLs must include the repo path segment because this is a GitHub Pages project site
+        # (https://<owner>.github.io/<repo>/), not a root user/org site.
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
         shell: pwsh
@@ -131,24 +122,95 @@ jobs:
 
           $taggedVersions = foreach ($t in $tags) {
             if ($t -match $semverRe) {
+              # Stable releases (no prerelease) have Stable=1; prerelease builds have Stable=0.
+              # Sorting descending by Stable places stable (1) before prerelease (0) of the same version.
               $stable = if ([string]::IsNullOrEmpty($Matches['prerelease'])) { 1 } else { 0 }
               [PSCustomObject]@{
-                Tag    = $t
-                Major  = [int]$Matches['major']
-                Minor  = [int]$Matches['minor']
-                Patch  = [int]$Matches['patch']
-                Stable = $stable
+                Tag        = $t
+                Major      = [int]$Matches['major']
+                Minor      = [int]$Matches['minor']
+                Patch      = [int]$Matches['patch']
+                Stable     = $stable
+                PreRelease = $Matches['prerelease']
               }
             }
           }
 
-          $orderedTags = $taggedVersions |
-            Sort-Object -Property Major, Minor, Patch, Stable -Descending |
-            Select-Object -ExpandProperty Tag
+          # Sort descending by full SemVer precedence (Major, Minor, Patch, Stable, PreRelease)
+          # Convert to a mutable list so we can use a custom comparison for proper SemVer prerelease ordering.
+          $tagList = [System.Collections.Generic.List[object]]::new()
+          foreach ($item in $taggedVersions) {
+            [void]$tagList.Add($item)
+          }
 
+          $comparison = [System.Comparison[object]]{
+            param($a, $b)
+
+            # Compare Major, Minor, Patch (descending)
+            if ($a.Major -ne $b.Major) { return [Math]::Sign($b.Major - $a.Major) }
+            if ($a.Minor -ne $b.Minor) { return [Math]::Sign($b.Minor - $a.Minor) }
+            if ($a.Patch -ne $b.Patch) { return [Math]::Sign($b.Patch - $a.Patch) }
+
+            # Compare Stable flag (descending: stable=1 > prerelease=0)
+            if ($a.Stable -ne $b.Stable) { return [Math]::Sign($b.Stable - $a.Stable) }
+
+            # At this point, Major/Minor/Patch/Stable are equal.
+            # If both are stable (no prerelease), they are equal for our purposes.
+            $aPre = [string]$a.PreRelease
+            $bPre = [string]$b.PreRelease
+
+            if ([string]::IsNullOrEmpty($aPre) -and [string]::IsNullOrEmpty($bPre)) { return 0 }
+
+            # Both should be prereleases when Stable is 0, but handle any unexpected cases gracefully.
+            if ([string]::IsNullOrEmpty($aPre) -and -not [string]::IsNullOrEmpty($bPre)) { return -1 }
+            if (-not [string]::IsNullOrEmpty($aPre) -and [string]::IsNullOrEmpty($bPre)) { return 1 }
+
+            $aIds = $aPre -split '\.'
+            $bIds = $bPre -split '\.'
+            $maxLen = [Math]::Max($aIds.Length, $bIds.Length)
+
+            for ($i = 0; $i -lt $maxLen; $i++) {
+              if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
+              if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
+
+              $aId = $aIds[$i]
+              $bId = $bIds[$i]
+
+              $aIsNum = [int]::TryParse($aId, [ref]([int]$null))
+              $bIsNum = [int]::TryParse($bId, [ref]([int]$null))
+
+              if ($aIsNum -and $bIsNum) {
+                $aVal = [int]$aId
+                $bVal = [int]$bId
+                if ($aVal -ne $bVal) { return [Math]::Sign($bVal - $aVal) }
+              }
+              elseif ($aIsNum -and -not $bIsNum) {
+                # Numeric identifiers have lower precedence than non-numeric.
+                return 1
+              }
+              elseif (-not $aIsNum -and $bIsNum) {
+                return -1
+              }
+              else {
+                $cmp = [string]::CompareOrdinal($aId, $bId)
+                if ($cmp -ne 0) { return -$cmp }
+              }
+            }
+
+            # All identifiers equal
+            return 0
+          }
+
+          $tagList.Sort($comparison)
+          # We implemented comparison for descending SemVer order directly in the comparison.
+          $orderedTags = $tagList | Select-Object -ExpandProperty Tag
+
+          # Build the base path for this GitHub Pages project site: /<repo-name>/
+          # GITHUB_REPOSITORY is "owner/repo"; we need just the repo name.
           $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
           $base = if ($repoName) { "/$repoName/" } else { "/" }
 
+          # "latest" points to the versions/latest/ folder; each version points to versions/<tag>/.
           [array]$versions = @([PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" })
           foreach ($t in $orderedTags) {
             $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
@@ -158,8 +220,76 @@ jobs:
             Set-Content -Path 'docfx_project/_site/versions.json' -Encoding utf8NoBOM
           Write-Host "Generated versions.json with $($versions.Count) version(s): $($versions | ForEach-Object { $_.version })"
 
+      - name: Clean up stale root files from gh-pages
+        # Before deploying the latest docs to the site root, remove any pre-existing
+        # root-level files and folders from the gh-pages branch (except the versions/
+        # directory, CNAME, and .nojekyll) so that stale DocFX assets from a previous
+        # build do not linger on the live site.
+        # The versions/ folder is preserved so that all versioned docs remain accessible
+        # while the root is refreshed with the new build.
+        if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $branchExists = git ls-remote --heads origin gh-pages
+          if (-not $branchExists) {
+            Write-Host "ℹ️ gh-pages branch does not exist yet – skipping stale-file cleanup."
+            exit 0
+          }
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git remote set-url origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
+
+          git fetch origin gh-pages
+          # Create a local tracking branch only if it does not already exist
+          git show-ref --verify --quiet refs/heads/gh-pages
+          if ($LASTEXITCODE -ne 0) {
+            git branch gh-pages origin/gh-pages
+          }
+
+          $WORK_DIR = Join-Path $env:RUNNER_TEMP 'gh-pages-clean'
+          # Remove a leftover worktree from a previous failed run, if any
+          git worktree remove "$WORK_DIR" --force 2>&1 | Out-Null
+          if (Test-Path $WORK_DIR) { Remove-Item $WORK_DIR -Recurse -Force }
+          git worktree add "$WORK_DIR" gh-pages
+
+          # Remove all root-level items EXCEPT:
+          #   .git         – Git metadata (worktree pointer file)
+          #   CNAME        – Custom domain config (if present)
+          #   .nojekyll    – Tells GitHub Pages not to run Jekyll
+          #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
+          Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
+            $_.Name -ne '.git' -and
+            $_.Name -ne 'CNAME' -and
+            $_.Name -ne '.nojekyll' -and
+            $_.Name -ne 'versions'
+          } | Remove-Item -Recurse -Force
+
+          git -C "$WORK_DIR" add -A
+          git -C "$WORK_DIR" diff --cached --quiet
+          if ($LASTEXITCODE -ne 0) {
+            git -C "$WORK_DIR" commit `
+              -m "chore: clean up stale root DocFX assets before redeploy [skip ci]"
+            git -C "$WORK_DIR" push origin HEAD:gh-pages
+            Write-Host "✅ Stale root files removed from gh-pages."
+          } else {
+            Write-Host "ℹ️ No stale files found in gh-pages root – nothing to clean."
+          }
+
+          git worktree remove "$WORK_DIR" --force
+
       - name: Compute destination directory
-        if: steps.check-docfx.outputs.has-docfx == 'true'
+        # Determines the versioned subfolder name for the docs deployment (e.g. /v1.2.3/).
+        # Uses the explicit 'version' input when provided; otherwise falls back to
+        # github.ref_name so the workflow works without callers passing a version.
+        # Sanitization steps (applied in order):
+        #   1. Replace forward slashes with hyphens (prevents nested paths).
+        #   2. Replace any character outside [A-Za-z0-9._-] with a hyphen.
+        #   3. Collapse consecutive hyphens into one.
+        #   4. Strip leading dots and hyphens (avoids hidden/awkward directory names).
+        #   5. Fall back to "latest" if the result is empty, ".", or "..".
         id: dest
         env:
           INPUT_VERSION: ${{ inputs.version }}
@@ -177,7 +307,18 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "dir=$sanitized"
 
       - name: Deploy docs to GitHub Pages
-        if: steps.check-docfx.outputs.has-docfx == 'true' && inputs.deploy_to_pages != false
+        # Assembles the full gh-pages state and pushes a single commit, avoiding the
+        # multiple sequential pushes that would trigger pages-build-deployment repeatedly.
+        #
+        # Layout written to gh-pages in one commit:
+        #   versions/<version>/   – versioned docs (real DocFX index.html)
+        #   versions/latest/      – latest alias   (real DocFX index.html) [deploy_as_latest only]
+        #   /                     – version-picker index.html + shared assets [deploy_as_latest only]
+        #
+        # Stale root files from the previous build are removed before copying new content,
+        # so outdated DocFX assets do not linger.  The versions/ folder is always preserved
+        # so that all prior versioned docs remain accessible.
+        if: inputs.deploy_to_pages != false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -214,18 +355,22 @@ jobs:
           # Ensure .nojekyll exists so GitHub Pages does not run Jekyll
           New-Item -ItemType File -Path (Join-Path $WORK_DIR '.nojekyll') -Force | Out-Null
 
-          # Deploy versioned docs
+          # Deploy versioned docs (real DocFX index.html — before version picker overwrites it)
           $versionedDir = Join-Path $WORK_DIR "versions/$($env:VERSION_DIR)"
           New-Item -ItemType Directory -Force -Path $versionedDir | Out-Null
           Copy-Item -Path "$siteDir/*" -Destination $versionedDir -Recurse -Force
           Write-Host "✅ Copied docs to versions/$($env:VERSION_DIR)/"
 
           if ($env:DEPLOY_AS_LATEST -eq 'true') {
+            # Deploy to versions/latest/ (real DocFX index.html)
             $latestDir = Join-Path $WORK_DIR 'versions/latest'
             New-Item -ItemType Directory -Force -Path $latestDir | Out-Null
             Copy-Item -Path "$siteDir/*" -Destination $latestDir -Recurse -Force
             Write-Host "✅ Copied docs to versions/latest/"
 
+            # Generate version-picker index.html and overwrite _site/index.html.
+            # This happens AFTER the versioned copies above, so those directories
+            # retain the real DocFX landing page while the root gets the picker.
             $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
             $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
             $versions = Get-Content "$siteDir/versions.json" -Raw | ConvertFrom-Json
@@ -248,6 +393,7 @@ jobs:
             $html | Set-Content -Path "$siteDir/index.html" -Encoding utf8NoBOM
             Write-Host "Generated version-picker index.html with $($versions.Count) version link(s)."
 
+            # Deploy version picker + shared assets to site root
             Copy-Item -Path "$siteDir/*" -Destination $WORK_DIR -Recurse -Force
             Write-Host "✅ Copied version picker to site root"
           }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,21 +1,32 @@
-# PR validation workflow for template pack repository
-# Builds all template projects and runs security scanning
-# No test stage — this repo contains only dotnet new templates
+# Sequential PR validation workflow with coverage gating
+# Stage 1: Linux tests with 90% coverage requirement
+# Stage 2: Windows .NET (5.0-10.0) and .NET Framework (4.6.2-4.8.1) tests (only if Linux passes)
+# Stage 3: macOS tests (only if Stage 2 passes)
 #
 # SECURITY NOTE:
-# - Uses pull_request_target to run workflow from the trusted main branch
+# - Uses pull_request_target to run workflow from the trusted main branch, not from the PR branch
 # - This prevents malicious workflow YAML changes in untrusted PR branches from taking effect
-# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code
-# - Configuration files (.editorconfig, etc.) are fetched from main to prevent bypasses
-# - persist-credentials: false prevents the checkout token from being written to git config
+# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code from the base repo
+# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
+#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
+# - If a PR changes any of these protected configuration files, CI explicitly fails with instructions
+#   for a maintainer to manually review and verify the changes before merging
+# - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
+#   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
+# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
+#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
+# - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
-name: PR Checks
+name: PR Checks v3 (Gated)
 
 permissions:
   contents: read
 
+env:
+  CODECOV_MINIMUM: 90
+  
 on:
-  pull_request_target:
+  pull_request_target:  # Runs from the main branch, not from PR branch
     branches:
       - main
 
@@ -39,11 +50,26 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Fetch trusted gitleaks config from main
+        # Prevent PR from modifying .gitleaks.toml to bypass the scan
+        run: |
+          git fetch origin main --depth=1
+          git checkout origin/main -- .gitleaks.toml 2>/dev/null || true
+        shell: bash
+
       - name: Run gitleaks
+        # gitleaks-action@v2 does not support pull_request_target, so invoke the CLI directly
+        # Pinned to a specific version with SHA256 checksum verification for supply-chain safety
         run: |
           GITLEAKS_VERSION="8.24.0"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar xz -C /usr/local/bin gitleaks
+          GITLEAKS_SHA256="cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4"
+          mkdir -p "$HOME/.local/bin"
+          TARBALL="$(mktemp)"
+          curl -sSfL -o "$TARBALL" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c - || { echo "Checksum verification failed!"; exit 1; }
+          tar xzf "$TARBALL" -C "$HOME/.local/bin" gitleaks
+          rm -f "$TARBALL"
+          export PATH="$HOME/.local/bin:$PATH"
           gitleaks detect --source . --verbose --redact
         shell: bash
 
@@ -56,18 +82,210 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     outputs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
-
+      
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+      
+      - name: Detect protected configuration file changes
+        # Skip for Dependabot — its bumps to protected files (e.g. Directory.Build.props)
+        # are legitimate. The guard's threat model is human PR authors disabling analyzers
+        # in their own PRs; it does not apply to a trusted GitHub-controlled bot whose
+        # only action is package-version updates.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Checking for changes to protected configuration files in this PR..."
+          
+          # Verify main-branch ref is available (it was fetched in the previous step)
+          if ! git cat-file -e main-branch 2>/dev/null; then
+            echo "❌ main-branch ref not found - cannot detect configuration file changes"
+            exit 1
+          fi
+          
+          changed_files=()
+          
+          # Check exact file matches against main branch git objects
+          # 2>/dev/null suppresses output when a file doesn't exist in one ref (new/deleted file),
+          # which git diff handles correctly via its exit code
+          exact_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+          )
+          
+          for config_file in "${exact_files[@]}"; do
+            if ! git diff --quiet main-branch HEAD -- "$config_file" 2>/dev/null; then
+              changed_files+=("$config_file")
+            fi
+          done
+          
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
+          while IFS= read -r file; do
+            changed_files+=("$file")
+          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          
+          if [ ${#changed_files[@]} -gt 0 ]; then
+            echo ""
+            echo "⚠️  PROTECTED CONFIGURATION FILES CHANGED IN THIS PR:"
+            for file in "${changed_files[@]}"; do
+              echo "  - $file"
+            done
+            echo ""
+            echo "❌ CI uses the main branch version of these files to prevent security bypasses."
+            echo "   The PR's changes to these files were NOT tested by CI."
+            echo "   A maintainer must manually review and verify these changes before merging."
+            echo ""
+            echo "To proceed, a maintainer should:"
+            echo "  1. Review the configuration changes in this PR carefully"
+            echo "  2. Test the changes locally to confirm they work correctly"
+            echo "  3. Merge with awareness that CI did not validate these configuration changes"
+            exit 1
+          else
+            echo "✅ No protected configuration files changed - CI fully validates this PR"
+          fi
+      
+      - name: Check for .NET project files
+        id: check-projects
+        run: |
+          if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
+            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "✅ Found .NET project files - .NET build and test jobs will run"
+          else
+            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
+          fi
+
+  # ============================================================================
+  # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
+  # ============================================================================
+  test-linux-core: 
+    name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
+    runs-on:  ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+      
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          # Fetch the main branch
           git fetch origin main:main-branch
 
+          # List of configuration files that should come from trusted main branch
           config_files=(
             ".editorconfig"
             "Directory.Build.props"
@@ -79,8 +297,11 @@ jobs:
             ".github/workflows/*.yaml"
           )
 
+          # Copy each configuration file from main branch if it exists
           for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
               git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
@@ -89,6 +310,7 @@ jobs:
                 fi
               done
             else
+              # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
                 git show "main-branch:$config_file" > "$config_file"
@@ -101,81 +323,345 @@ jobs:
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
-      - name: Detect protected configuration file changes
+      # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
+      # repository so APT verifies the package via GPG instead of a plain wget download.
+      - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          echo "Checking for changes to protected configuration files in this PR..."
+          echo "deb https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          sudo apt-get update -q
+          sudo apt-get install --yes libssl1.1
+          sudo rm /etc/apt/sources.list.d/focal-security.list
 
-          if ! git cat-file -e main-branch 2>/dev/null; then
-            echo "❌ main-branch ref not found - cannot detect configuration file changes"
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore and build (exclude .NET Framework-only projects)
+        run: |
+          echo "Finding .NET project files in repository (via find command)..."
+          
+          # Filter out projects that ONLY target .NET Framework 4.x
+          # Multi-targeting projects (e.g., net8.0;net48) will be INCLUDED
+          projects=()
+          project_found=false
+          
+          while IFS= read -r -d '' proj; do
+            project_found=true
+            # Check if project has any .NET 5+ target framework
+            # Look for: net5.0, net6.0, net7.0, net8.0, net9.0, net10.0, or netcoreapp, netstandard
+            # Normalize line endings to handle multi-line <TargetFramework> / <TargetFrameworks> elements
+            if tr -d '\n\r' < "$proj" | grep -qE '<TargetFramework[s]?>.*(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp|netstandard)'; then
+              projects+=("$proj")
+              echo "✓ Including: $proj (has .NET 5+ or .NET Core target)"
+            else
+              echo "⊘ Excluding: $proj (Framework-only, incompatible with Linux)"
+            fi
+          done < <(find . -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          
+          if [ "$project_found" = false ]; then
+            echo "❌ No .NET projects found."
+            echo "This should not occur as detect-projects already verified project existence."
             exit 1
           fi
-
-          changed_files=()
-
-          exact_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-          )
-
-          for config_file in "${exact_files[@]}"; do
-            if ! git diff --quiet main-branch HEAD -- "$config_file" 2>/dev/null; then
-              changed_files+=("$config_file")
+          
+          if [ ${#projects[@]} -eq 0 ]; then
+            echo "❌ No compatible .NET projects found."
+            echo "All projects target only .NET Framework 4.x, which is incompatible with Linux."
+            exit 1
+          fi
+          
+          echo ""
+          echo "=========================================="
+          echo "Projects to build:"
+          echo "=========================================="
+          printf '%s\n' "${projects[@]}"
+          echo ""
+          
+          # Restore each project
+          echo "Restoring projects..."
+          for proj in "${projects[@]}"; do
+            echo "Restoring: $proj"
+            dotnet restore "$proj" || exit 1
+          done
+          
+          echo ""
+          echo "Building projects..."
+          # Build each project, handling multi-targeting projects
+          # For multi-targeting projects, build only Linux-compatible frameworks (.NET 5.0+, .NET Core, .NET Standard)
+          for proj in "${projects[@]}"; do
+            echo "Building: $proj"
+            
+            # Extract target frameworks via MSBuild property evaluation.
+            # This handles multi-line <TargetFrameworks> XML, conditional property groups,
+            # and TFMs inherited from Directory.Build.props — all of which break grep-based parsing.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp[0-9.]+|netstandard[0-9.]+)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⚠️  No Linux-compatible frameworks found in $proj"
+              continue
+            fi
+            
+            # Check if this is a multi-targeting project
+            framework_count=$(echo "$frameworks" | wc -l)
+            
+            if [ "$framework_count" -eq 1 ]; then
+              # Single target framework - build normally
+              echo "  Target framework: $frameworks"
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
+            else
+              # Multi-targeting project - build each compatible framework separately
+              echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
+              while IFS= read -r fw; do
+                [ -z "$fw" ] && continue
+                echo "  Building framework: $fw"
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+              done <<< "$frameworks"
             fi
           done
+          
+          echo ""
+          echo "✅ All compatible projects built successfully"
 
-          while IFS= read -r file; do
-            changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+      - name: Run tests with coverage (.NET Core 5.0 - 10.0)
+        run: |
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          # The downstream coverage steps already handle the no-coverage-files case.
+          if [ ! -d ./tests ]; then
+            echo "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          fi
 
-          if [ ${#changed_files[@]} -gt 0 ]; then
+          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+
+          if [ ${#test_projects[@]} -eq 0 ]; then
+            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
+          fi
+          
+          echo "=========================================="
+          echo "Found test projects:"
+          echo "=========================================="
+          printf '%s\n' "${test_projects[@]}"
+          echo ""
+          
+          for test_proj in "${test_projects[@]}"; do
+            echo "=========================================="
+            echo "Testing project: $test_proj"
+            echo "=========================================="
+            
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance — both break grep-based parsing).
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp3\.1)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⊘ Skipping: No compatible .NET 5.0-10.0 target frameworks found"
+              echo ""
+              continue
+            fi
+            
+            echo "Target frameworks: $(echo "$frameworks" | tr '\n' ' ')"
             echo ""
-            echo "⚠️  PROTECTED CONFIGURATION FILES CHANGED IN THIS PR:"
-            for file in "${changed_files[@]}"; do
-              echo "  - $file"
-            done
+            
+            # Test each framework that the project actually targets
+            while IFS= read -r fw; do
+              [ -z "$fw" ] && continue
+              echo "Testing framework: $fw"
+              
+              dotnet test "$test_proj" \
+                --configuration Release \
+                --framework "$fw" \
+                --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
+                --results-directory "./TestResults" \
+                --logger "console;verbosity=minimal" || exit 1
+            done <<< "$frameworks"
             echo ""
-            echo "❌ CI uses the main branch version of these files to prevent security bypasses."
-            echo "   The PR's changes to these files were NOT tested by CI."
-            echo "   A maintainer must manually review and verify these changes before merging."
+          done
+
+      - name: Check for coverage files
+        id: check-coverage
+        run: |
+          if find TestResults -type f -name "coverage.cobertura.xml" 2>/dev/null | grep -q .; then
+            echo "has-coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage files found"
+          else
+            echo "has-coverage=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No coverage files found - skipping coverage report generation"
+          fi
+
+      - name: Install ReportGenerator
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        run: |
+          reportgenerator \
+            -reports:"TestResults/**/coverage.cobertura.xml" \
+            -targetdir:"CoverageReport" \
+            -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
+
+      - name: Enforce 90% coverage threshold
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        run: |
+          if [ ! -f CoverageReport/Summary.txt ]; then
+            echo "❌ Coverage report not generated!"
+            exit 1
+          fi
+
+          echo "Coverage Summary:"
+          cat CoverageReport/Summary.txt
+          echo ""
+          
+          failed_projects=""
+          threshold=${CODECOV_MINIMUM:-90}
+          
+          while read -r line; do
+            # Match lines with module names and percentages
+            if echo "$line" | grep -qE '^[^ ].*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+              module=$(echo "$line" | awk '{print $1}')
+              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')
+              
+              echo "Checking module: '$module' - Coverage: ${percent}%"
+              
+              if [ "$percent" -lt "$threshold" ]; then
+                echo "  ❌ FAIL: Below ${threshold}% threshold"
+                failed_projects="$failed_projects $module (${percent}%)"
+              else
+                echo "  ✅ PASS: Meets ${threshold}% threshold"
+              fi
+            fi
+          done < CoverageReport/Summary.txt
+
+          if [ -n "$failed_projects" ]; then
+            echo ""
+            echo "=========================================="
+            echo "❌ COVERAGE GATE FAILED"
+            echo "=========================================="
+            echo "Projects below ${threshold}% coverage: $failed_projects"
+            echo ""
+            echo "Stage 1 failed. Windows, macOS, and .NET Framework tests will NOT run."
             exit 1
           else
-            echo "✅ No protected configuration files changed - CI fully validates this PR"
+            echo ""
+            echo "=========================================="
+            echo "✅ COVERAGE GATE PASSED"
+            echo "=========================================="
+            echo "All projects meet ${threshold}% coverage threshold."
+            echo "Proceeding to Stage 2 (Windows and macOS tests)."
           fi
 
-      - name: Check for .NET project files
-        id: check-projects
-        run: |
-          if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
-            echo "has-projects=true" >> $GITHUB_OUTPUT
-            echo "✅ Found .NET project files"
-          else
-            echo "has-projects=false" >> $GITHUB_OUTPUT
-            echo "ℹ️  No .NET project files found - skipping build"
-          fi
+      - name: Upload Linux coverage results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-linux
+          path: |
+            TestResults/
+            CoverageReport/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-output
+          path: |
+            src/**/bin/Release
+            tests/**/bin/Release
 
   # ============================================================================
-  # BUILD: Validate all template projects compile and pack
+  # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
   # ============================================================================
-  build-and-validate:
-    name: "Build & Validate Templates"
+  test-windows:
+    name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     runs-on: windows-latest
-    needs: detect-projects
+    needs: [detect-projects, test-linux-core]
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
+      
+      - name: Fetch trusted configuration files from main branch
+        shell: pwsh
+        run: |
+          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          $configFiles = @(
+            ".editorconfig",
+            "Directory.Build.props",
+            "Directory.Build.targets",
+            "BannedSymbols.txt"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          foreach ($configFile in $configFiles) {
+            # Check if file exists in main branch
+            $exists = git cat-file -e "main-branch:$configFile" 2>&1
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "  ✓ Copying $configFile from main branch"
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+            } else {
+              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
+            }
+          }
+          
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          foreach ($pattern in $globPatterns) {
+            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
+            foreach ($file in $files) {
+              if ($file) {
+                Write-Host "  ✓ Copying $file from main branch"
+                $dir = Split-Path -Parent $file
+                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+              }
+            }
+          }
+          
+          Write-Host ""
+          Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          # Fetch the main branch
           git fetch origin main:main-branch
 
+          # List of configuration files that should come from trusted main branch
           $configFiles = @(
             ".editorconfig",
             "Directory.Build.props",
@@ -183,7 +669,9 @@ jobs:
             "BannedSymbols.txt"
           )
 
+          # Copy each configuration file from main branch if it exists
           foreach ($configFile in $configFiles) {
+            # Check if file exists in main branch
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
@@ -193,110 +681,741 @@ jobs:
             }
           }
 
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          foreach ($pattern in $globPatterns) {
+            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
+            foreach ($file in $files) {
+              if ($file) {
+                Write-Host "  ✓ Copying $file from main branch"
+                $dir = Split-Path -Parent $file
+                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+              }
+            }
+          }
+
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
-
-          # Reset exit code — git cat-file -e leaves $LASTEXITCODE=1 for missing files
-          exit 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
             8.0.x
             9.0.x
             10.0.x
 
-      - name: Restore and build all projects (Release)
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build solution
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh
         run: |
-          $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj'
+          $ErrorActionPreference = 'Stop'
 
-          if ($projects.Count -eq 0) {
-            Write-Error "❌ No projects found in src/ directory"
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          if (-not (Test-Path -Path './tests' -PathType Container)) {
+            Write-Host "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          }
+
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
+
+          if (@($testProjects).Count -eq 0) {
+            Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
+          }
+          
+          Write-Host "==========================================" -ForegroundColor Cyan
+          Write-Host "Found test projects:" -ForegroundColor Cyan
+          Write-Host "==========================================" -ForegroundColor Cyan
+          $testProjects | ForEach-Object { Write-Host $_.FullName -ForegroundColor White }
+          Write-Host ""
+          
+          foreach ($testProj in $testProjects) {
+            Write-Host "==========================================" -ForegroundColor Cyan
+            Write-Host "Testing project: $($testProj.FullName)" -ForegroundColor Cyan
+            Write-Host "==========================================" -ForegroundColor Cyan
+            
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            $content = Get-Content $testProj.FullName -Raw
+            $tfmMatch = [regex]::Match($content, '<TargetFramework[s]?>([^<]+)</TargetFramework[s]?>')
+            
+            if (-not $tfmMatch.Success) {
+              Write-Host "⊘ Skipping: No target frameworks found" -ForegroundColor Yellow
+              Write-Host ""
+              continue
+            }
+            
+            # Split by semicolon for multi-targeting projects
+            $frameworks = $tfmMatch.Groups[1].Value -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0|462|47|471|472|48|481|coreapp3\.1)$' }
+            
+            if ($frameworks.Count -eq 0) {
+              Write-Host "⊘ Skipping: No compatible .NET 5.0-10.0 or Framework 4.6.2-4.8.1 target frameworks found" -ForegroundColor Yellow
+              Write-Host ""
+              continue
+            }
+            
+            Write-Host "Target frameworks: $($frameworks -join ', ')" -ForegroundColor White
+            Write-Host ""
+            
+            # Test each framework; collect coverage only for .NET 5.0+ TFMs.
+            # netcoreapp3.1 and net4x are tested but excluded from coverage:
+            # netcoreapp3.1 has no matching test TFM on Linux (Stage 1) so its numbers
+            # would not be comparable; net4x cannot use the XPlat collector on Windows.
+            foreach ($fw in $frameworks) {
+              Write-Host "Testing framework: $fw" -ForegroundColor Yellow
+
+              if ($fw -match '^net([5-9]|[1-9][0-9]+)\.') {
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=normal"
+              } else {
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --logger "console;verbosity=normal"
+              }
+
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "Tests failed for $fw in $($testProj.Name)"
+                exit 1
+              }
+            }
+            Write-Host ""
+          }
+
+      - name: Check for coverage files
+        id: check-coverage
+        run: |
+          if (Get-ChildItem -Path TestResults -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue) {
+            echo "has-coverage=true" >> $env:GITHUB_OUTPUT
+            Write-Host "✅ Coverage files found"
+          } else {
+            echo "has-coverage=false" >> $env:GITHUB_OUTPUT
+            Write-Host "ℹ️  No coverage files found - skipping coverage report generation"
+          }
+        shell: pwsh
+
+      - name: Install ReportGenerator
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        shell: pwsh
+        run: |
+          reportgenerator `
+            -reports:"TestResults/**/coverage.cobertura.xml" `
+            -targetdir:"CoverageReport" `
+            -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
+
+      - name: Enforce 90% coverage threshold
+        if: steps.check-coverage.outputs.has-coverage == 'true'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "CoverageReport/Summary.txt")) {
+            Write-Error "❌ Coverage report not generated!"
             exit 1
           }
 
-          foreach ($proj in $projects) {
-            Write-Host "📦 Restoring $($proj.Name)" -ForegroundColor Cyan
-            dotnet restore $proj.FullName
+          Write-Host "Coverage Summary:"
+          Get-Content "CoverageReport/Summary.txt"
+          Write-Host ""
 
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "❌ Restore failed for $($proj.Name)"
-              exit $LASTEXITCODE
-            }
+          $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $failedProjects = @()
 
-            Write-Host "🔨 Building $($proj.Name)" -ForegroundColor Cyan
-            dotnet build $proj.FullName --no-restore --configuration Release
+          foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
+            if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+              $module  = $Matches[1]
+              $percent = [int][math]::Floor([double]$Matches[2])
 
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "❌ Build failed for $($proj.Name)"
-              exit $LASTEXITCODE
-            }
-          }
+              Write-Host "Checking module: '$module' - Coverage: ${percent}%"
 
-          Write-Host "✅ All projects built successfully" -ForegroundColor Green
-
-      - name: Pack NuGet packages (validate packaging)
-        shell: pwsh
-        run: |
-          $packagesPath = Join-Path $PWD 'nuget-packages'
-          New-Item -ItemType Directory -Force -Path $packagesPath | Out-Null
-
-          $packProjects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' | Where-Object {
-            $_.Name -like '*template.pack*'
-          }
-
-          foreach ($proj in $packProjects) {
-            Write-Host "📦 Packing $($proj.Name)" -ForegroundColor Cyan
-            dotnet pack $proj.FullName --no-build --configuration Release --output $packagesPath
-
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "❌ Pack failed for $($proj.Name)"
-              exit $LASTEXITCODE
+              if ($percent -lt $threshold) {
+                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
+                $failedProjects += "$module (${percent}%)"
+              } else {
+                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+              }
             }
           }
 
-          $packages = Get-ChildItem -Path $packagesPath -Filter '*.nupkg'
-          Write-Host "✅ Created $($packages.Count) NuGet package(s):" -ForegroundColor Green
-          $packages | ForEach-Object { Write-Host "   $($_.Name)" }
+          if ($failedProjects.Count -gt 0) {
+            Write-Host ""
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "❌ COVERAGE GATE FAILED" -ForegroundColor Red
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "Projects below ${threshold}% coverage: $($failedProjects -join ', ')" -ForegroundColor Red
+            Write-Host ""
+            Write-Host "Stage 2 failed. macOS tests will NOT run."
+            exit 1
+          }
+
+          Write-Host ""
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "✅ COVERAGE GATE PASSED" -ForegroundColor Green
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "All projects meet ${threshold}% coverage threshold."
+          Write-Host "Proceeding to Stage 3 (macOS tests)."
+
+      - name: Upload Windows coverage results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-windows
+          path: |
+            TestResults/
+            CoverageReport/
 
   # ============================================================================
-  # SECURITY: DevSkim static analysis
+  # STAGE 3: macOS Tests (Gated by Stage 2)
   # ============================================================================
-  security-scan:
-    name: "Security Scan (DevSkim)"
-    runs-on: ubuntu-latest
-    needs: detect-projects
+  test-macos-core:
+    name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
+    runs-on: macos-latest
+    needs: [detect-projects, test-windows]
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
+      
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          # Fetch the main branch
+          git fetch origin main:main-branch
+
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore and build (exclude .NET Framework-only projects)
+        run: |
+          echo "Enumerating tracked .NET project files (git ls-files)..."
+          
+          # Filter out projects that ONLY target .NET Framework 4.x
+          # Multi-targeting projects (e.g., net8.0;net48) will be INCLUDED
+          projects=()
+          project_found=false
+          
+          while IFS= read -r -d '' proj; do
+            project_found=true
+            # Check if project has any .NET 6+ target framework (macOS ARM64 compatible)
+            # Look for: net6.0, net7.0, net8.0, net9.0, net10.0
+            # Normalize newlines to spaces so multi-line <TargetFrameworks> elements are matched correctly
+            if tr $'\n' ' ' < "$proj" | grep -qE '<TargetFramework[s]?>[^<]*net(6\.0|7\.0|8\.0|9\.0|10\.0)'; then
+              projects+=("$proj")
+              echo "✓ Including: $proj (has .NET 6+ target)"
+            else
+              echo "⊘ Excluding: $proj (no .NET 6+ target, incompatible with macOS ARM64)"
+            fi
+          done < <(git ls-files -z -- '*.csproj' '*.vbproj' '*.fsproj')
+          
+          if [ "$project_found" = false ]; then
+            echo "❌ No .NET projects found."
+            echo "This should not occur as detect-projects already verified project existence."
+            exit 1
+          fi
+          
+          if [ ${#projects[@]} -eq 0 ]; then
+            echo "❌ No compatible .NET projects found."
+            echo "All projects lack .NET 6+ targets, which are required for macOS ARM64."
+            exit 1
+          fi
+          
+          echo ""
+          echo "=========================================="
+          echo "Projects to build (excluding .NET Framework-only projects):"
+          echo "=========================================="
+          printf '%s\n' "${projects[@]}"
+          echo ""
+          
+          # Restore each project
+          echo "Restoring projects..."
+          for proj in "${projects[@]}"; do
+            echo "Restoring: $proj"
+            dotnet restore "$proj" || exit 1
+          done
+          
+          echo ""
+          echo "Building projects..."
+          # Build each project, handling multi-targeting projects
+          # For multi-targeting projects, build only macOS ARM64-compatible frameworks (net6.0-10.0)
+          for proj in "${projects[@]}"; do
+            echo "Building: $proj"
+            
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance). Filter to .NET 6+ for macOS ARM64 compatibility.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⚠️  No macOS ARM64-compatible frameworks found in $proj"
+              continue
+            fi
+            
+            # Check if this is a multi-targeting project
+            framework_count=$(echo "$frameworks" | wc -l)
+            
+            if [ "$framework_count" -eq 1 ]; then
+              # Single target framework - build normally
+              echo "  Target framework: $frameworks"
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
+            else
+              # Multi-targeting project - build each compatible framework separately
+              echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
+              while IFS= read -r fw; do
+                [ -z "$fw" ] && continue
+                echo "  Building framework: $fw"
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+              done <<< "$frameworks"
+            fi
+          done
+          
+          echo ""
+          echo "✅ All compatible projects built successfully"
+
+      - name:  Run tests (.NET 6.0 - 10.0 only - ARM64 compatible)
+        run: |
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          if [ ! -d ./tests ]; then
+            echo "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          fi
+
+          test_projects=()
+          while IFS= read -r -d '' file; do
+          test_projects+=("$file")
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+
+          if [ ${#test_projects[@]} -eq 0 ]; then
+            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
+          fi
+          
+          echo "=========================================="
+          echo "Found test projects:"
+          echo "=========================================="
+          printf '%s\n' "${test_projects[@]}"
+          echo ""
+          
+          for test_proj in "${test_projects[@]}"; do
+            echo "=========================================="
+            echo "Testing project: $test_proj"
+            echo "=========================================="
+            
+            # Extract target frameworks via MSBuild property evaluation (handles multi-line XML
+            # and Directory.Build.props inheritance). Filter to .NET 6+ for macOS ARM64 compatibility.
+            # Falls back from <TargetFrameworks> (multiple) to <TargetFramework> (single).
+            tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFrameworks 2>/dev/null \
+              | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFrameworks[=:][[:space:]]*//' | tr -d '[:space:]')
+            if [ -z "$tfm_raw" ]; then
+              tfm_raw=$(dotnet msbuild "$test_proj" -noLogo -getProperty:TargetFramework 2>/dev/null \
+                | grep -v '^[[:space:]]*$' | tail -n1 | sed 's/^TargetFramework[=:][[:space:]]*//' | tr -d '[:space:]')
+            fi
+            frameworks=$(printf '%s' "$tfm_raw" | tr ';' '\n' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⊘ Skipping: No compatible .NET 6.0-10.0 target frameworks found (ARM64 required)"
+              echo ""
+              continue
+            fi
+            
+            echo "Target frameworks: $(echo "$frameworks" | tr '\n' ' ')"
+            echo ""
+            
+            # Test each framework that the project actually targets
+            # All frameworks here are net6.0+ so all get coverage
+            while IFS= read -r fw; do
+              [ -z "$fw" ] && continue
+              echo "Testing framework: $fw"
+
+              dotnet test "$test_proj" \
+                --configuration Release \
+                --framework "$fw" \
+                --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
+                --results-directory "./TestResults" \
+                --logger "console;verbosity=normal" || exit 1
+            done <<< "$frameworks"
+            echo ""
+          done
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        run: |
+          if find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null | grep -q .; then
+            reportgenerator \
+              -reports:"TestResults/**/coverage.cobertura.xml" \
+              -targetdir:"CoverageReport" \
+              -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
+          else
+            echo "ℹ️  No coverage files found - skipping report generation"
+          fi
+
+      - name: Enforce 90% coverage threshold
+        run: |
+          if [ ! -f "CoverageReport/Summary.txt" ]; then
+            echo "❌ Coverage report not generated!"
+            exit 1
+          fi
+
+          echo "Coverage Summary:"
+          cat CoverageReport/Summary.txt
+          echo ""
+
+          THRESHOLD=${CODECOV_MINIMUM:-90}
+          FAILED=0
+
+          while IFS= read -r line; do
+            if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+              MODULE=$(echo "$line" | awk '{print $1}')
+              PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
+              echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
+              if [ "$PERCENT" -lt "$THRESHOLD" ]; then
+                echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
+                FAILED=1
+              else
+                echo "  ✅ PASS: Meets ${THRESHOLD}% threshold"
+              fi
+            fi
+          done < CoverageReport/Summary.txt
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo ""
+            echo "=========================================="
+            echo "❌ COVERAGE GATE FAILED"
+            echo "=========================================="
+            echo "One or more modules are below ${THRESHOLD}% coverage."
+            echo "Stage 3 failed."
+            exit 1
+          fi
+
+          echo ""
+          echo "=========================================="
+          echo "✅ COVERAGE GATE PASSED"
+          echo "=========================================="
+          echo "All modules meet ${THRESHOLD}% coverage threshold."
+
+      - name: Upload macOS coverage results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-macos
+          path: |
+            TestResults/
+            CoverageReport/
+
+      - name: Display macOS architecture info
+        if: always()
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "ℹ️  macOS Testing Notes"
+          echo "=========================================="
+          echo "Architecture: $(uname -m)"
+          echo ""
+          echo "Skipped frameworks (no ARM64 support):"
+          echo "  - .NET 5.0 ❌"
+          echo ""
+          echo "Tested frameworks (ARM64 compatible):"
+          echo "  - .NET 6.0 ✅"
+          echo "  - .NET 7.0 ✅"
+          echo "  - .NET 8.0 ✅"
+          echo "  - .NET 9.0 ✅"
+          echo "  - .NET 10.0 ✅"
+          echo ""
+          echo ".NET Core 5.0 are tested on Linux and Windows"
+          echo ""
+
+      - name: Summarize pipeline result
+        run: |
+          echo "=========================================="
+          echo "✅ ALL STAGES PASSED"
+          echo "=========================================="
+          echo "Stage 1: Linux tests + 90% coverage ✅"
+          echo "Stage 2: Windows .NET Core & .NET Framework tests ✅"
+          echo "Stage 3: macOS tests ✅"
+          echo ""
+          echo "PR is ready to merge! 🎉"
+
+  # ============================================================================
+  # Security Scan (Runs in parallel, independently of .NET jobs)
+  # ============================================================================
+  security-scan:
+    name: "Security Scan (DevSkim)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+      
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          # Fetch the main branch
+          git fetch origin main:main-branch
+
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Install DevSkim CLI
         run: dotnet tool install --global Microsoft.CST.DevSkim.CLI
 
-      - name: Run DevSkim Security Scan
-        run: devskim analyze --source-code . --file-format text -E --ignore-rule-ids DS176209,DS137138 --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**" --output-file devskim-results.txt
-
-      - name: Show DevSkim Results in Summary
-        if: failure()
+      - name: Run DevSkim security scan
         run: |
-          echo "### DevSkim Security Issues Found"
-          cat devskim-results.txt
-        shell: bash
+          devskim analyze \
+            --source-code . \
+            --file-format text \
+            --output-file devskim-results.txt \
+            --ignore-rule-ids DS176209 \
+            --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**"
 
-      - name: Upload DevSkim Results as Artifact
+      - name: Display security scan results
+        if: always()
+        run: |
+          if [ -f devskim-results.txt ]; then
+            echo "=========================================="
+            echo "DevSkim Security Scan Results"
+            echo "=========================================="
+            cat devskim-results.txt
+            echo ""
+            
+            if grep -qi "error\|critical\|high" devskim-results.txt; then
+              echo "❌ Security issues detected - review required"
+              exit 1
+            else
+              echo "✅ No critical security issues found"
+            fi
+          else
+            echo "✅ No security issues found"
+          fi
+
+      - name: Upload security scan results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: devskim-results
           path: devskim-results.txt
+          if-no-files-found: warn

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>**/bin/**/*.cs;**/obj/**/*.cs</ExcludeByFile>
+          <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary
Picks up the remaining canonical drift after [#147](https://github.com/Chris-Wolfgang/console-app-template/pull/147) and [#146](https://github.com/Chris-Wolfgang/console-app-template/pull/146) merged:

- **.editorconfig**: refresh from canonical (repo-template#325 IDE0022 + repo-template#326 per-folder analyzer relaxations).
- **pr.yaml**: refresh from canonical (#322 + #323 + #324).
- **docfx.yaml**: refresh from canonical (#327).
- **coverlet.runsettings**: new from #324.

## Skipped intentionally
- **Directory.Build.props**: this repo doesn't have one, and adding it would change behavior of `src/ConsoleAppTemplate/Content/` (the template content that `dotnet new console-app-template` instantiates).
- **Per-csproj analyzer refs in Content/ConsoleAppTemplate.csproj**: those are intentional defaults the template ships with — out of scope for drift sync.

## Test plan
- [x] Local Release build of Content/ConsoleAppTemplate.csproj clean (0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)