### PR TITLE
Fix Windows stage: per-project restore (no root solution)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -713,8 +713,8 @@ jobs:
       - name: Restore and build all projects
         shell: pwsh
         run: |
-          # Find solution file first, fall back to per-project restore
-          $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+          # Find solution file first (full recursive search), fall back to per-project restore
+          $solution = Get-ChildItem -Path . -Recurse -Include "*.sln", "*.slnx" -ErrorAction SilentlyContinue | Select-Object -First 1
 
           if ($solution) {
             Write-Host "Found solution: $($solution.FullName)"
@@ -724,9 +724,14 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           } else {
             Write-Host "No solution file found, restoring and building projects individually..."
-            $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
-            if (-not $projects) {
-              $projects = Get-ChildItem -Path . -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
+            $projects = @(Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+            if ($projects.Count -eq 0) {
+              $projects = @(Get-ChildItem -Path . -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+            }
+
+            if ($projects.Count -eq 0) {
+              Write-Error "❌ No solution or project files found - nothing to build"
+              exit 1
             }
 
             foreach ($proj in $projects) {

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -710,11 +710,36 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore and build all projects
+        shell: pwsh
+        run: |
+          # Find solution file first, fall back to per-project restore
+          $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
 
-      - name: Build solution
-        run: dotnet build --no-restore --configuration Release
+          if ($solution) {
+            Write-Host "Found solution: $($solution.FullName)"
+            dotnet restore $solution.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            dotnet build $solution.FullName --no-restore --configuration Release
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } else {
+            Write-Host "No solution file found, restoring and building projects individually..."
+            $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
+            if (-not $projects) {
+              $projects = Get-ChildItem -Path . -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue
+            }
+
+            foreach ($proj in $projects) {
+              Write-Host "Restoring $($proj.Name)"
+              dotnet restore $proj.FullName
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              Write-Host "Building $($proj.Name)"
+              dotnet build $proj.FullName --no-restore --configuration Release
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            }
+          }
+
+          Write-Host "✅ All projects built successfully"
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh


### PR DESCRIPTION
## Summary
The pr.yaml from repo-template was synced back to this repo, reintroducing the bare `dotnet restore` at root that fails because this template pack has no solution file at root.

This is the same root cause we hit before — the repo-template multi-stage workflow doesn't fit a template pack repo. The Stage 2 Windows job runs `dotnet restore` and `dotnet build` from root with no solution/project specified.

## Fix
Replace bare commands with logic that:
1. Searches for a solution file (.sln/.slnx) recursively
2. Falls back to per-project restore/build if no solution exists

This unblocks dependabot PRs #149, #150, and #151.

## Note
This is a recurring issue. The repo-template workflow keeps getting synced here. Consider either:
- Adding a sync exclusion for this repo's pr.yaml
- Updating repo-template's workflow to handle the no-solution case
- Using `dotnet restore src/` instead of bare `dotnet restore` in repo-template

🤖 Generated with [Claude Code](https://claude.com/claude-code)