### PR TITLE
Gracefully skip macOS coverage gate when no tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1214,8 +1214,8 @@ jobs:
       - name: Enforce 90% coverage threshold
         run: |
           if [ ! -f "CoverageReport/Summary.txt" ]; then
-            echo "❌ Coverage report not generated!"
-            exit 1
+            echo "ℹ️  No coverage report found - skipping coverage gate (no tests in this repo)"
+            exit 0
           fi
 
           echo "Coverage Summary:"


### PR DESCRIPTION
## Summary
Stage 3 macOS hard-fails when no coverage report exists, but the preceding "Generate coverage report" step already gracefully skips when no coverage files are found. This is inconsistent with Linux and Windows stages which both guard the coverage gate on `has-coverage` output.

This template pack repo has no tests, so no coverage is expected.

Changed `exit 1` → `exit 0` with informational message in the macOS coverage gate.

This unblocks dependabot PRs #149 and #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)