### PR TITLE
pr.yaml: trust Dependabot in protected-files guards

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,6 +64,11 @@ jobs:
           persist-credentials: false
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           git fetch origin main:main-branch
@@ -100,6 +105,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Detect protected configuration file changes
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Checking for changes to protected configuration files in this PR..."
 
@@ -169,6 +179,11 @@ jobs:
           persist-credentials: false
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."


### PR DESCRIPTION
## Summary
Adds the standard Dependabot exemption to every `Fetch trusted configuration files from main branch` and `Detect protected configuration file changes` step in `pr.yaml`. Brings this repo in line with `repo-template` and the rest of the fleet.

## Background
The protected-files mechanism in this workflow has two parts:
1. **Fetch** steps overwrite `.editorconfig`, `Directory.Build.props`, `Directory.Build.targets`, `BannedSymbols.txt`, `*.globalconfig`, `*.ruleset`, and `.github/workflows/*.y(a)ml` with the version from `main`.
2. A **Detect** step explicitly fails CI if the PR touched any of those files.

Together they prevent malicious PRs from disabling analyzers. But neither was gated on the PR author, so Dependabot PRs that bump analyzer versions (which live in `Directory.Build.props`) either had their bumps silently reverted or failed CI outright — both forcing a maintainer override to merge what should be a hands-off auto-merge.

## Fix
Adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` to every protected-files step, with a comment explaining the threat-model rationale.

## Why this is safe
- Threat model is human PR authors disabling analyzers in their own PRs.
- Dependabot is GitHub-controlled and not spoofable; its only action is package-version updates.
- Pattern already used by `repo-template/.github/workflows/pr.yaml` and 24+ other repos in the fleet.

## Test plan
- [ ] After merge, a Dependabot PR bumping an analyzer in `Directory.Build.props` should pass these protected-files steps (or skip them) instead of being blocked.
- [ ] Human PRs that touch protected files still fail CI / get overwritten by main's version.
