### PR TITLE
Bump Node.js 20-era action versions to Node.js 24 majors

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -58,7 +58,7 @@ jobs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -173,7 +173,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -213,7 +213,7 @@ jobs:
           exit 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -284,13 +284,13 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -309,7 +309,7 @@ jobs:
 
       - name: Upload DevSkim Results as Artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: devskim-results
           path: devskim-results.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -272,7 +272,7 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: nuget-packages
           path: ./packages
@@ -346,7 +346,7 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages


### PR DESCRIPTION
## Summary

Two workflows in this repo still pinned to GitHub Actions versions that ship with Node.js 20, which GitHub is removing from runners on **Sep 16, 2026** (Node.js 24 becomes the default on **Jun 2, 2026**). Bumps to the same majors used in the canonical `repo-template`.

## Changes

**`.github/workflows/pr.yaml`**
- `actions/checkout@v4` → `@v6`
- `actions/setup-dotnet@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v7`

**`.github/workflows/release.yaml`**
- `actions/download-artifact@v4` → `@v8.0.1`

All other action pins in this repo were already up to date.

## Background

Audited via cross-repo sweep — this repo was one of only 2 (out of 24 active Chris-Wolfgang repos) still pinning Node 20-era versions. The other is `D20-Dice` (separate PR).

## Test plan

- [ ] CI matrix runs green
- [ ] No new deprecation annotations in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)