### PR TITLE
ci: bump softprops/action-gh-release v2.5.0 → v3.0.0 (fleet sync)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -352,7 +352,7 @@ jobs:
           path: ./nuget-packages
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |


### PR DESCRIPTION
Closes #188.

## Summary

Bumps `softprops/action-gh-release` from v2.5.0 → v3.0.0 in `.github/workflows/release.yaml` to match the rest of the fleet.

## Change

```diff
- uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+ uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
```

SHA stays pinned per workflow-hardening policy.

## After merge

Smoke a release via `gh release create` to confirm `release.yaml` still completes cleanly.