### PR TITLE
pr.yaml: quote $GITHUB_OUTPUT writes (SC2086)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -156,10 +156,10 @@ jobs:
         id: check-projects
         run: |
           if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
-            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "has-projects=true" >> "$GITHUB_OUTPUT"
             echo "✅ Found .NET project files"
           else
-            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping build"
           fi
 


### PR DESCRIPTION
Downstream propagation of [repo-template#426](https://github.com/Chris-Wolfgang/repo-template/pull/426).

Quotes the four bash `echo ... >> $GITHUB_OUTPUT` writes in pr.yaml so actionlint's shellcheck integration stops flagging SC2086 info-level findings. GitHub sets `GITHUB_OUTPUT` to a fixed path with no spaces or globs, so the prior form was safe in practice — but the quoted form is the universally-correct shape.

Surfaced when [ETL-Csv#125](https://github.com/Chris-Wolfgang/ETL-Csv/pull/125) added actionlint to that repo's workflow-security check. Every fleet repo that syncs pr.yaml inherits the bug; this PR brings console-app-template in line ahead of the next template sync.

PowerShell refs (`$env:GITHUB_OUTPUT`) are PowerShell syntax, not bash — shellcheck doesn't flag them and they don't need quoting.

**Heads-up:** pr.yaml is a protected file under its own "Detect .NET Projects" guard. Expect that check to fail on this PR; admin-bypass merge to land.