### PR TITLE
Enable Release-scoped TreatWarningsAsErrors in console template (#165)

### DIFF
--- a/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
+++ b/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
@@ -76,6 +76,9 @@ internal class SampleCommand
     {
         logger.LogInformation("Starting {Command}", GetType().Name);
 
+        // TODO Remove along with SampleConfiguration - demonstrates reading bound configuration
+        logger.LogDebug("CommandTimeout is {CommandTimeout}", configuration.CommandTimeout);
+
         try
         {
             // TODO Validate command line arguments

--- a/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
+++ b/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Treat warnings as errors in Release builds -->
+    <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
 	<PackageVersion>0.1.0</PackageVersion>
 	<LangVersion>latest</LangVersion>
 	<Copyright>Copyright {copyright year} {author}</Copyright>

--- a/src/ConsoleAppTemplate/Content/Framework/ConfigurationFileMethod.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/ConfigurationFileMethod.cs
@@ -1,0 +1,19 @@
+namespace ConsoleAppTemplate.Framework;
+
+/// <summary>
+/// Specifies how configuration files are loaded when calling
+/// <see cref="IHostBuilderExtensions.AddConfigurationFile"/>.
+/// </summary>
+internal enum ConfigurationFileMethod
+{
+    /// <summary>
+    /// All environments share a single AppSettings.json file.
+    /// </summary>
+    SingleFile,
+
+    /// <summary>
+    /// Each environment loads its own AppSettings.{environment}.json file,
+    /// selected by the DOTNET_ENVIRONMENT variable.
+    /// </summary>
+    OneFilePerEnvironment
+}

--- a/src/ConsoleAppTemplate/Content/Framework/IHostBuilderExtensions.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/IHostBuilderExtensions.cs
@@ -3,14 +3,6 @@ using Microsoft.Extensions.Hosting;
 
 namespace ConsoleAppTemplate.Framework
 {
-    internal enum ConfigurationFileMethod
-    {
-        SingleFile,
-        OneFilePerEnvironment
-    }
-
-
-
     internal static class IHostBuilderExtensions
     {
         /// <summary>
@@ -37,7 +29,7 @@ namespace ConsoleAppTemplate.Framework
             {
                 ConfigurationFileMethod.SingleFile => AddSingleConfigFile(builder, optional, reloadOnChange),
                 ConfigurationFileMethod.OneFilePerEnvironment => AddConfigFileForEnvironment(builder, optional, reloadOnChange),
-                _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+                _ => throw new ArgumentOutOfRangeException(nameof(method), method, message: null)
             };
         }
 
@@ -51,7 +43,7 @@ namespace ConsoleAppTemplate.Framework
         )
          {
             builder
-                .ConfigureAppConfiguration((context, configurationBuilder) =>
+                .ConfigureAppConfiguration((_, configurationBuilder) =>
                 {
                     configurationBuilder
                         .SetBasePath(AppContext.BaseDirectory)
@@ -78,7 +70,7 @@ namespace ConsoleAppTemplate.Framework
             }
 
             builder
-                .ConfigureAppConfiguration((context, configurationBuilder) =>
+                .ConfigureAppConfiguration((_, configurationBuilder) =>
                 {
                     configurationBuilder
                         .SetBasePath(AppContext.BaseDirectory)

--- a/src/ConsoleAppTemplate/Content/Program.cs
+++ b/src/ConsoleAppTemplate/Content/Program.cs
@@ -54,7 +54,7 @@ namespace ConsoleAppTemplate
                     })
                     
                     // Configure dependency injection
-                    .ConfigureServices((context, serviceCollection) =>
+                    .ConfigureServices((_, serviceCollection) =>
                     {
                         serviceCollection
                             .AddSingleton<IReporter, ConsoleReporter>()
@@ -107,22 +107,24 @@ namespace ConsoleAppTemplate
 
             logger.LogDebug("Starting {Command}", GetType().Name);
 
+            // TODO Remove along with SampleConfiguration - demonstrates reading bound configuration
+            logger.LogDebug("CommandTimeout is {CommandTimeout}", sampleConfiguration.CommandTimeout);
+
 
             // TODO if you are not using sub commands then you can remove the
-            // two lines below
+            // three lines below
+            reporter.Warn("No sub command specified");
             application.ShowHelp();
             return ExitCode.Success;
 
 
-            // TODO If you are using sub commands then you can remove the
-            // lines below and use the code above
-            
-            // TODO Add your code here
-            reporter.Warn("Your code here");
-
-
-            // TODO Return 0 for success and any positive number for failure
-            return ExitCode.Success;
+            // TODO If you are not using sub commands then you can remove the
+            // lines above and add your code here, e.g.
+            //
+            //     reporter.Warn("Your code here");
+            //
+            //     // Return 0 for success and any positive number for failure
+            //     return ExitCode.Success;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds the fleet-canonical `<TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>` to the ConsoleAppTemplate content project, so apps generated from the template inherit the Release-only warnings-as-errors convention (C2 fleet initiative).
- Fixes the 11 analyzer errors this immediately surfaced in the template content:
  - **MA0048**: `ConfigurationFileMethod` enum moved to its own file
  - **MA0003**: named the `message:` parameter on `ArgumentOutOfRangeException`
  - **RCS1163/S3257**: unused lambda `context` parameters replaced with discards
  - **RCS1163**: injected `SampleConfiguration` is now actually read (logged) in `Program.OnExecute` and `SampleCommand.OnExecuteAsync`, so the DI demo is real instead of decorative
  - **CS0162**: the unreachable no-subcommand demo block converted to a guidance comment; active path now warns "No sub command specified" before showing help

## Verification
`dotnet build ConsoleAppTemplate.csproj -c Release` and `dotnet build src/ConsoleAppTemplate.sln -c Release`: 0 warnings, 0 errors.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)