### PR TITLE
Code review: fix generated-code defects in template content (#170)

### DIFF
--- a/src/ConsoleAppTemplate/Content/Framework/ConsoleColors.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/ConsoleColors.cs
@@ -4,53 +4,53 @@
     {
         // https://ss64.com/nt/syntax-ansi.html
 
-        public static readonly string Reset         = "\e[0m";
-        public static readonly string Bold          = "\e[1m";
-        public static readonly string Underline     = "\e[4m";
-        public static readonly string NoUnderline   = "\e[24m";
-        public static readonly string ReverseText   = "\e[7m";
-        public static readonly string PositiveText  = "\e[27m";
+        public static readonly string Reset         = "\u001b[0m";
+        public static readonly string Bold          = "\u001b[1m";
+        public static readonly string Underline     = "\u001b[4m";
+        public static readonly string NoUnderline   = "\u001b[24m";
+        public static readonly string ReverseText   = "\u001b[7m";
+        public static readonly string PositiveText  = "\u001b[27m";
 
 
 
         internal static class Background
         {
-            public static readonly string Black        = "\e[40m";
-            public static readonly string Red          = "\e[41m";
-            public static readonly string Green        = "\e[42m";
-            public static readonly string Yellow       = "\e[43m";
-            public static readonly string Blue         = "\e[44m";
-            public static readonly string Magenta      = "\e[45m";
-            public static readonly string Cyan         = "\e[46m";
-            public static readonly string LightGray    = "\e[47m";
-            public static readonly string Gray         = "\e[100m";
-            public static readonly string LightRed     = "\e[101m";
-            public static readonly string LightGreen   = "\e[102m";
-            public static readonly string LightYellow  = "\e[103m";
-            public static readonly string LightBlue    = "\e[104m";
-            public static readonly string LightMagenta = "\e[105m";
-            public static readonly string LightCyan    = "\e[106m";
-            public static readonly string White        = "\e[107m";
+            public static readonly string Black        = "\u001b[40m";
+            public static readonly string Red          = "\u001b[41m";
+            public static readonly string Green        = "\u001b[42m";
+            public static readonly string Yellow       = "\u001b[43m";
+            public static readonly string Blue         = "\u001b[44m";
+            public static readonly string Magenta      = "\u001b[45m";
+            public static readonly string Cyan         = "\u001b[46m";
+            public static readonly string LightGray    = "\u001b[47m";
+            public static readonly string Gray         = "\u001b[100m";
+            public static readonly string LightRed     = "\u001b[101m";
+            public static readonly string LightGreen   = "\u001b[102m";
+            public static readonly string LightYellow  = "\u001b[103m";
+            public static readonly string LightBlue    = "\u001b[104m";
+            public static readonly string LightMagenta = "\u001b[105m";
+            public static readonly string LightCyan    = "\u001b[106m";
+            public static readonly string White        = "\u001b[107m";
         }
 
         internal static class Foreground
         {
-            public static readonly string Black        = "\e[30m";
-            public static readonly string Red          = "\e[31m";
-            public static readonly string Green        = "\e[32m";
-            public static readonly string Yellow       = "\e[33m";
-            public static readonly string Blue         = "\e[34m";
-            public static readonly string Magenta      = "\e[35m";
-            public static readonly string Cyan         = "\e[36m";
-            public static readonly string LightGray    = "\e[37m";
-            public static readonly string DarkGray     = "\e[90m";
-            public static readonly string LightRed     = "\e[91m";
-            public static readonly string LightGreen   = "\e[92m";
-            public static readonly string LightYellow  = "\e[93m";
-            public static readonly string LightBlue    = "\e[94m";
-            public static readonly string LightMagenta = "\e[95m";
-            public static readonly string LightCyan    = "\e[96m";
-            public static readonly string White        = "\e[97m";
+            public static readonly string Black        = "\u001b[30m";
+            public static readonly string Red          = "\u001b[31m";
+            public static readonly string Green        = "\u001b[32m";
+            public static readonly string Yellow       = "\u001b[33m";
+            public static readonly string Blue         = "\u001b[34m";
+            public static readonly string Magenta      = "\u001b[35m";
+            public static readonly string Cyan         = "\u001b[36m";
+            public static readonly string LightGray    = "\u001b[37m";
+            public static readonly string DarkGray     = "\u001b[90m";
+            public static readonly string LightRed     = "\u001b[91m";
+            public static readonly string LightGreen   = "\u001b[92m";
+            public static readonly string LightYellow  = "\u001b[93m";
+            public static readonly string LightBlue    = "\u001b[94m";
+            public static readonly string LightMagenta = "\u001b[95m";
+            public static readonly string LightCyan    = "\u001b[96m";
+            public static readonly string White        = "\u001b[97m";
         }
     }
 }

--- a/src/ConsoleAppTemplate/Content/Framework/IHostBuilderExtensions.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/IHostBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace ConsoleAppTemplate.Framework
             {
                 ConfigurationFileMethod.SingleFile => AddSingleConfigFile(builder, optional, reloadOnChange),
                 ConfigurationFileMethod.OneFilePerEnvironment => AddConfigFileForEnvironment(builder, optional, reloadOnChange),
-                _ => throw new ArgumentOutOfRangeException(nameof(method), method, message: null)
+                _ => throw new ArgumentOutOfRangeException(nameof(method), method, $"Unsupported {nameof(ConfigurationFileMethod)} value.")
             };
         }
 

--- a/src/ConsoleAppTemplate/Content/Model/Framework/ConfigurationFile.cs
+++ b/src/ConsoleAppTemplate/Content/Model/Framework/ConfigurationFile.cs
@@ -1,9 +1,0 @@
-﻿namespace ConsoleAppTemplate.Model.Framework;
-
-internal record ConfigurationFile
-{
-    public required string Name { get; init; }
-    public bool Optional { get; init; }
-    public bool ReloadOnChange { get; init; }
-
-}

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -28,7 +28,8 @@ internal class EtlSubCommandTemplate
     /// <summary>
     /// The maximum number of items to process. If not specified, all items will be processed.
     /// </summary>
-    [Range(0, int.MaxValue, ErrorMessage = "Current item count cannot be less than 0.")]
+    [Option(Description = "The maximum number of items to process. If not specified, all items will be processed")]
+    [Range(0, int.MaxValue, ErrorMessage = "Maximum item count cannot be less than 0.")]
     public int? MaxItemCount { get; set; }
 
 
@@ -37,7 +38,8 @@ internal class EtlSubCommandTemplate
     /// The number of items to skip before starting to process. This is useful for pagination or skipping initial items.
     /// If not specified, no items will be skipped.
     /// </summary>
-    [Range(0, int.MaxValue, ErrorMessage = "Current item count cannot be less than 0.")]
+    [Option(Description = "The number of items to skip before starting to process. If not specified, no items will be skipped")]
+    [Range(0, int.MaxValue, ErrorMessage = "Skip item count cannot be less than 0.")]
     public int? SkipItemCount { get; set; }
 
 
@@ -58,7 +60,7 @@ internal class EtlSubCommandTemplate
         ILogger<EtlSubCommandTemplate> logger
     )
     {
-        logger.LogDebug("Starting {command}", GetType().Name);
+        logger.LogDebug("Starting {Command}", GetType().Name);
 
         try
         {
@@ -71,7 +73,7 @@ internal class EtlSubCommandTemplate
             (
                 report =>
                 {
-                    logger.LogDebug("Current count: {count}", report.CurrentItemCount);
+                    logger.LogDebug("Current count: {Count}", report.CurrentItemCount);
                     console.WriteLine($"Current count: {report.CurrentItemCount}");
                 }
             );
@@ -94,6 +96,7 @@ internal class EtlSubCommandTemplate
 
             // Execute the ETL process asynchronously
             // await ExecuteEtlAsync(extractor, transformer, loader, progress);
+            await Task.Yield(); // Simulate doing work - remove once ExecuteEtlAsync above is uncommented
 
             logger.LogInformation("ETL process completed successfully.");
         }
@@ -104,7 +107,7 @@ internal class EtlSubCommandTemplate
             return ExitCode.ApplicationError;
         }
 
-        logger.LogDebug("Completed {command}", GetType().Name);
+        logger.LogDebug("Completed {Command}", GetType().Name);
 
         return ExitCode.Success;
     }

--- a/src/SubCommandTemplate/Content/SubCommandTemplate.cs
+++ b/src/SubCommandTemplate/Content/SubCommandTemplate.cs
@@ -29,7 +29,7 @@ internal class SubCommandTemplate
         ILogger<SubCommandTemplate> logger
     )
     {
-        logger.LogDebug("Starting {command}", GetType().Name);
+        logger.LogDebug("Starting {Command}", GetType().Name);
 
         try
         {
@@ -38,6 +38,7 @@ internal class SubCommandTemplate
 
 
             // TODO Your code here
+            await Task.Yield(); // Simulate doing work - remove once your code awaits something
 
         }
         catch (Exception e)
@@ -47,7 +48,7 @@ internal class SubCommandTemplate
             return ExitCode.ApplicationError;
         }
 
-        logger.LogDebug("Completed {command}", GetType().Name);
+        logger.LogDebug("Completed {Command}", GetType().Name);
 
         return ExitCode.Success;
     }


### PR DESCRIPTION
**Stack 1/3** (base: vNext) — from the #170 full code-review pass.

## Summary
- **ConsoleColors**: replace the `\e` escape (requires C# 13 / SDK ≥ 9) with `\u001b` — projects generated with the .NET 8 SDK (the documented minimum) previously failed to compile with CS1009
- **SubCommandTemplate / EtlSubCommandTemplate**: add an `await Task.Yield()` placeholder so generated `async` methods don't emit CS1998 (which becomes a build **error** under the Release-scoped TreatWarningsAsErrors landing in #246)
- **EtlSubCommandTemplate**: add the missing `[Option]` attributes to `MaxItemCount`/`SkipItemCount` — without them McMaster never binds these from the command line — and fix the copy-pasted `[Range]` error messages
- **Serilog placeholders**: PascalCase (`{Command}`, `{Count}`) to match SampleCommand and Serilog convention
- **Dead code**: delete the unreferenced `ConfigurationFile` record

## Verification
`dotnet build ConsoleAppTemplate.csproj -c Release`: 0 warnings, 0 errors. Confirmed the `sample` subcommand name empirically via `--help` (launchSettings profiles are correct as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)