### PR TITLE
release.yaml: fix v0.5.0 release-run failures (smoke-test exit leak, ungated docs deploy)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,27 @@ jobs:
     name: Validate Release Build
     runs-on: windows-latest
     if: github.repository != 'Chris-Wolfgang/repo-template'
+    outputs:
+      has-docfx: ${{ steps.detect-docfx.outputs.has-docfx }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Detect docfx project
+        # Gates the trigger-docs job below. This repo ships docfx_project/ as a
+        # placeholder (.gitkeep only, no docfx.json); calling docfx.yaml without
+        # a config fails the whole release run at `docfx metadata`.
+        id: detect-docfx
+        shell: pwsh
+        run: |
+          if (Test-Path "docfx_project/docfx.json") {
+            "has-docfx=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          } else {
+            Write-Host "::notice::No docfx_project/docfx.json - documentation build/deploy will be skipped."
+            "has-docfx=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
 
       - name: Validate release tag matches csproj version
         shell: pwsh
@@ -531,9 +547,19 @@ jobs:
             # Uninstall in reverse so install order doesn't leak across runs.
             for ($i = $cleanupQueue.Count - 1; $i -ge 0; $i--) {
               $nupkg = $cleanupQueue[$i]
-              dotnet new uninstall $nupkg 2>$null | Out-Null
+              dotnet new uninstall $nupkg 2>&1 | Out-Null
+              if ($LASTEXITCODE -ne 0) {
+                Write-Host "::warning::Cleanup: dotnet new uninstall $nupkg exited $LASTEXITCODE (ignored - does not affect the smoke-test result)"
+              }
             }
           }
+
+          # The v0.5.0 run failed HERE with no error output: pwsh reports the
+          # last native command's exit code as the step result, and the swallowed
+          # cleanup uninstall above returned 1 AFTER the smoke test had already
+          # passed. Success/failure is decided by the explicit exits in the try
+          # block; reaching this line means the smoke test succeeded.
+          exit 0
 
       - name: Generate SBOM (CycloneDX)
         if: steps.check-packages.outputs.has-packages == 'true'
@@ -747,6 +773,7 @@ jobs:
   trigger-docs:
     name: Build & Deploy Documentation
     needs: validate-release
+    if: needs.validate-release.outputs.has-docfx == 'true'
     permissions:
       contents: write  # Required by docfx.yaml to push to gh-pages branch
     uses: ./.github/workflows/docfx.yaml


### PR DESCRIPTION
## Summary
The v0.5.0 release run ([28987177060](https://github.com/Chris-Wolfgang/console-app-template/actions/runs/28987177060)) failed on two infrastructure issues — the release content itself validated fine:

### 1. Smoke-test exit-code leak (blocked publish-nuget)
The new template install/instantiate smoke test **passed** ("✅ Smoke test passed — templates install, list, and instantiate"), then the step exited 1 with no error: the `finally` cleanup runs `dotnet new uninstall ... 2>$null | Out-Null`, and pwsh reports the **last native command's exit code** as the step result. A failed (and silenced) cleanup uninstall failed the job after the fact, so `Publish to NuGet.org` was skipped — **v0.5.0 is not on NuGet yet**. Fix: surface cleanup failures as `::warning::` and end the step with an explicit `exit 0` (the try block's explicit exits already decide real failures).

### 2. Docs deploy crash (ungated docfx call)
`trigger-docs` calls docfx.yaml unconditionally, but this repo's `docfx_project/` is a `.gitkeep` placeholder with **no docfx.json** — `docfx metadata` died with `FileNotFoundException`. `validate-release` now emits a `has-docfx` output and `trigger-docs` is gated on it, mirroring the gate `verify-docs-build` already had. (Setting up actual DocFX content remains #112's call.)

## After merging
Re-publish the v0.5.0 release (Releases → v0.5.0 → edit → set to draft → publish again) to re-fire `release: published`. Expected result: validate → pack+smoke → verify-docs (skips, no docfx.json) → **publish-nuget runs for the first time** → docs deploy skipped cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)