### PR TITLE
release.yaml: tolerate missing coverage artifact in Attach Artifacts to Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -796,18 +796,27 @@ jobs:
           path: ./nuget-packages
 
       - name: Download coverage report artifact
+        # This repo has no test projects, so validate-release never uploads a
+        # release-coverage artifact and download-artifact hard-fails on the
+        # missing name (v0.5.0 second-run failure). Tolerate its absence; the
+        # zip step below only runs when the download actually produced files.
+        id: download-coverage
+        continue-on-error: true
         uses: actions/download-artifact@v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage
 
       - name: Zip coverage report
+        if: steps.download-coverage.outcome == 'success'
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           tag_name: ${{ github.event.release.tag_name }}
+          # release-coverage.zip is listed unconditionally but action-gh-release
+          # skips missing file patterns with a warning rather than failing.
           files: |
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.bom.json


### PR DESCRIPTION
## Summary
Third and final no-tests adaptation in release.yaml. The v0.5.0 re-run ([28988519515](https://github.com/Chris-Wolfgang/console-app-template/actions/runs/28988519515)) reached **Publish to NuGet.org: success** — the packages are live — but `Attach Artifacts to Release` failed with `Artifact not found for name: release-coverage`: with no test projects, `validate-release` never uploads a coverage artifact, and `actions/download-artifact` hard-fails on a missing name.

Fix: `continue-on-error: true` + step `id` on the coverage download, gate the zip step on `steps.download-coverage.outcome == 'success'`, and let `action-gh-release` skip the missing zip pattern (it warns rather than fails). The nupkgs and SBOMs still attach either way.

## Note on the release assets
Since publish succeeded, there's no need to re-run the whole release for this — after merging, the artifacts can be attached manually to the v0.5.0 release if wanted, or just left for the next release to exercise the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)