### PR TITLE
Add auto-generated --version option to the console template (#120)

### DIFF
--- a/src/ConsoleAppTemplate/Content/Program.cs
+++ b/src/ConsoleAppTemplate/Content/Program.cs
@@ -36,11 +36,14 @@ namespace ConsoleAppTemplate
         /// informational version (set via the csproj Version/PackageVersion), falling
         /// back to the assembly version when no informational version is present.
         /// </summary>
-        private static string? GetVersion() => Assembly
-            .GetEntryAssembly()?
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-            .InformationalVersion
-            ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+        private static string GetVersion()
+        {
+            var assembly = Assembly.GetEntryAssembly();
+
+            return assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? assembly?.GetName().Version?.ToString()
+                ?? "unknown";
+        }
 
 
 

--- a/src/ConsoleAppTemplate/Content/Program.cs
+++ b/src/ConsoleAppTemplate/Content/Program.cs
@@ -28,8 +28,23 @@ namespace ConsoleAppTemplate
     )]
     [Subcommand(typeof(SampleCommand))]
     // TODO Add additional sub commands here
+    [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
     internal class Program
     {
+        /// <summary>
+        /// Supplies the value shown by the --version option. Reads the assembly's
+        /// informational version (set via the csproj Version/PackageVersion), falling
+        /// back to the assembly version when no informational version is present.
+        /// </summary>
+        private static string? GetVersion() => Assembly
+            .GetEntryAssembly()?
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion
+            ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+
+
+
+
         private static async Task<int> Main(string[] args)
         {
             try


### PR DESCRIPTION
**Stack 1/3** (base: main) — quick-win batch.

## Summary
Adds McMaster's `[VersionOptionFromMember("--version", ...)]` to the generated Program class, backed by a `GetVersion()` member that reads the assembly informational version (csproj `Version`/`PackageVersion`, includes the SourceLink SHA suffix when present) with a fallback to the plain assembly version.

## Verification
`dotnet run -- --version` on the Content project prints `1.0.0+<sha>`; `--help` lists the new option. Release build clean.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)