### PR TITLE
Add THIRD-PARTY-NOTICES.md + template.json thirdPartyNotices (#20)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,40 @@
+# Third-Party Notices
+
+Projects generated from the templates in this repository reference the following third-party packages. Each package is owned by its respective authors and licensed under its own terms; the licenses below are as published on NuGet at the time of writing.
+
+## Wolfgang.Template.Console (`cwconsole`)
+
+| Package | Purpose | License |
+|---------|---------|---------|
+| [McMaster.Extensions.CommandLineUtils](https://www.nuget.org/packages/McMaster.Extensions.CommandLineUtils) | Command-line parsing (commands, subcommands, options) | Apache-2.0 |
+| [McMaster.Extensions.Hosting.CommandLine](https://www.nuget.org/packages/McMaster.Extensions.Hosting.CommandLine) | Generic-host integration for CommandLineUtils | Apache-2.0 |
+| [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) | Generic host, dependency injection, configuration | MIT |
+| [System.Configuration.ConfigurationManager](https://www.nuget.org/packages/System.Configuration.ConfigurationManager) | Configuration types | MIT |
+| [Serilog](https://www.nuget.org/packages/Serilog) | Structured logging | Apache-2.0 |
+| [Serilog.Exceptions](https://www.nuget.org/packages/Serilog.Exceptions) | Exception detail enrichment | MIT |
+| [Serilog.Extensions.Hosting](https://www.nuget.org/packages/Serilog.Extensions.Hosting) | Serilog ↔ generic host integration | Apache-2.0 |
+| [Serilog.Extensions.Logging](https://www.nuget.org/packages/Serilog.Extensions.Logging) | Serilog provider for Microsoft.Extensions.Logging | Apache-2.0 |
+| [Serilog.Settings.Configuration](https://www.nuget.org/packages/Serilog.Settings.Configuration) | Serilog configuration from AppSettings.json | Apache-2.0 |
+| [Serilog.Sinks.Console](https://www.nuget.org/packages/Serilog.Sinks.Console) | Console log sink | Apache-2.0 |
+| [Serilog.Sinks.File](https://www.nuget.org/packages/Serilog.Sinks.File) | Rolling-file log sink | Apache-2.0 |
+
+### Analyzers (build-time only, `PrivateAssets=all` — not shipped with the application)
+
+| Package | License |
+|---------|---------|
+| [AsyncFixer](https://www.nuget.org/packages/AsyncFixer) | MIT |
+| [Meziantou.Analyzer](https://www.nuget.org/packages/Meziantou.Analyzer) | MIT |
+| [Roslynator.Analyzers](https://www.nuget.org/packages/Roslynator.Analyzers) | Apache-2.0 |
+| [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp) | LGPL-3.0 |
+
+## Wolfgang.Template.Console.Subcommand (`cwsubcmd`)
+
+Adds a class that uses the packages already referenced by the host application (McMaster.Extensions.CommandLineUtils, Microsoft.Extensions.Logging); it introduces no additional package references.
+
+## Wolfgang.Template.Console.ETL-SubCommand (`cwsubcmdetl`)
+
+| Package | Purpose | License |
+|---------|---------|---------|
+| [Wolfgang.Etl.Abstractions](https://www.nuget.org/packages/Wolfgang.Etl.Abstractions) | ETL extract/transform/load abstractions | MIT |
+
+Plus the host application's existing packages, as with `cwsubcmd`.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -25,7 +25,7 @@ Projects generated from the templates in this repository reference the following
 | [AsyncFixer](https://www.nuget.org/packages/AsyncFixer) | MIT |
 | [Meziantou.Analyzer](https://www.nuget.org/packages/Meziantou.Analyzer) | MIT |
 | [Roslynator.Analyzers](https://www.nuget.org/packages/Roslynator.Analyzers) | Apache-2.0 |
-| [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp) | LGPL-3.0 |
+| [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp) | LGPL-3.0-only |
 
 ## Wolfgang.Template.Console.Subcommand (`cwsubcmd`)
 

--- a/src/ConsoleAppTemplate/Content/.template.config/template.json
+++ b/src/ConsoleAppTemplate/Content/.template.config/template.json
@@ -8,6 +8,7 @@
 	"sourceName": "ConsoleAppTemplate",
 	"description": "A console application preconfigured with additional package including McMaster's CommandLineUtils, Serilog and others",
 	"defaultName": "ConsoleApp",
+	"thirdPartyNotices": "https://github.com/Chris-Wolfgang/console-app-template/blob/main/THIRD-PARTY-NOTICES.md",
 
 	"baselines": {
 		"default": {

--- a/src/EtlSubCommandTemplate/Content/.template.config/template.json
+++ b/src/EtlSubCommandTemplate/Content/.template.config/template.json
@@ -8,6 +8,7 @@
 	"sourceName": "EtlSubCommandTemplate",
 	"description": "A preconfigured SubCommand for use with Wolfgang Console App Template and configured for building ETLs using Wolfgang.Etl.Abstractions",
 	"defaultName": "EtlSubCommand",
+	"thirdPartyNotices": "https://github.com/Chris-Wolfgang/console-app-template/blob/main/THIRD-PARTY-NOTICES.md",
 	"macros": [
 	],
 

--- a/src/SubCommandTemplate/Content/.template.config/template.json
+++ b/src/SubCommandTemplate/Content/.template.config/template.json
@@ -8,6 +8,7 @@
 	"sourceName": "SubCommandTemplate",
 	"description": "A preconfigured SubCommand for use with Wolfgang Console App Template",
 	"defaultName": "SubCommand",
+	"thirdPartyNotices": "https://github.com/Chris-Wolfgang/console-app-template/blob/main/THIRD-PARTY-NOTICES.md",
 	"macros": [
 	],
 


### PR DESCRIPTION
**Stack 2/3** (base: `quickwin/120-version-flag`) — quick-win batch.

## Summary
- Adds [THIRD-PARTY-NOTICES.md](../blob/quickwin/20-third-party-notices/THIRD-PARTY-NOTICES.md) listing every package the generated projects reference, per template, with licenses (runtime packages and build-only analyzers separated).
- Wires the `thirdPartyNotices` URL property into all three template.json files — `dotnet new` now prints *"This template contains technologies from parties other than Microsoft, see <link> for details"* at instantiation, exactly what #20 asked for (it cites this schema property).

## Verification
Packed + installed + instantiated `cwconsole`; the notice line appears with the correct link.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)