### PR TITLE
Polish the response-file template parameter (#49)

### DIFF
--- a/src/ConsoleAppTemplate/Content/.template.config/template.json
+++ b/src/ConsoleAppTemplate/Content/.template.config/template.json
@@ -24,6 +24,14 @@
 		"type": "project"
 	},
 
+	"forms": {
+		"toResponseFileHandling": {
+			"identifier": "replace",
+			"pattern": "^(Line|Space)Separated$",
+			"replacement": "ParseArgsAs$1Separated"
+		}
+	},
+
 	"symbols": {
 		"framework": {
 			"type": "parameter",
@@ -74,30 +82,33 @@
 
 		"response-file": {
 			"type": "parameter",
-			"description": "Response file support. Command line arguments can be added to a response file and the response can be passed in as though each argument was manually typed at the commandline",
+			"description": "Response file support. A response file is a text file of command line arguments that users can pass as @file.rsp instead of typing each argument at the command line",
 			"datatype": "choice",
 			"choices": [
 				{
 					"choice": "Disabled",
-					"description": "Disabled",
-					"displayName": "Disabled - No response file support.",
-					"documentation": ""
+					"displayName": "Disabled",
+					"description": "No response file support"
 				},
 				{
-					"choice": "ParseArgsAsLineSeparated",
-					"description": "Line separated",
-					"displayName": "Line separated - Each argument is on a new line.",
-					"documentation": ""
+					"choice": "LineSeparated",
+					"displayName": "Line separated",
+					"description": "Each argument in the response file is on its own line"
 				},
 				{
-					"choice": "ParseArgsAsSpaceSeparated",
-					"description": "Space separated",
-					"displayName": "Space separated - All arguments are on a single line in separated by spaces.",
-					"documentation": ""
+					"choice": "SpaceSeparated",
+					"displayName": "Space separated",
+					"description": "All arguments in the response file are on a single line, separated by spaces"
 				}
 			],
-			"replaces": "ParseArgsAsSpaceSeparated",
-			"defaultValue": "ParseArgsAsLineSeparated"
+			"defaultValue": "LineSeparated"
+		},
+
+		"response-file-handling": {
+			"type": "derived",
+			"valueSource": "response-file",
+			"valueTransform": "toResponseFileHandling",
+			"replaces": "ParseArgsAsSpaceSeparated"
 		},
 
 		"currentYear": {

--- a/src/EtlSubCommandTemplate/Content/.template.config/template.json
+++ b/src/EtlSubCommandTemplate/Content/.template.config/template.json
@@ -17,6 +17,14 @@
 		"type": "item"
 	},
 
+	"forms": {
+		"toResponseFileHandling": {
+			"identifier": "replace",
+			"pattern": "^(Line|Space)Separated$",
+			"replacement": "ParseArgsAs$1Separated"
+		}
+	},
+
 	"symbols": {
 		"ClassName": {
 			"type": "parameter",
@@ -51,30 +59,33 @@
 
 		"response-file": {
 			"type": "parameter",
-			"description": "Response file support. Command line arguments can be added to a response file and the response can be passed in as though each argument was manually typed at the commandline",
+			"description": "Response file support. A response file is a text file of command line arguments that users can pass as @file.rsp instead of typing each argument at the command line",
 			"datatype": "choice",
 			"choices": [
 				{
 					"choice": "Disabled",
-					"description": "Disabled",
-					"displayName": "Disabled - No response file support.",
-					"documentation": ""
+					"displayName": "Disabled",
+					"description": "No response file support"
 				},
 				{
-					"choice": "ParseArgsAsLineSeparated",
-					"description": "Line separated",
-					"displayName": "Line separated - Each argument is on a new line.",
-					"documentation": ""
+					"choice": "LineSeparated",
+					"displayName": "Line separated",
+					"description": "Each argument in the response file is on its own line"
 				},
 				{
-					"choice": "ParseArgsAsSpaceSeparated",
-					"description": "Space separated",
-					"displayName": "Space separated - All arguments are on a single line in separated by spaces.",
-					"documentation": ""
+					"choice": "SpaceSeparated",
+					"displayName": "Space separated",
+					"description": "All arguments in the response file are on a single line, separated by spaces"
 				}
 			],
-			"replaces": "ParseArgsAsSpaceSeparated",
-			"defaultValue": "ParseArgsAsLineSeparated"
+			"defaultValue": "LineSeparated"
+		},
+
+		"response-file-handling": {
+			"type": "derived",
+			"valueSource": "response-file",
+			"valueTransform": "toResponseFileHandling",
+			"replaces": "ParseArgsAsSpaceSeparated"
 		}
 	},
 	"primaryOutputs": [

--- a/src/SubCommandTemplate/Content/.template.config/template.json
+++ b/src/SubCommandTemplate/Content/.template.config/template.json
@@ -17,6 +17,14 @@
 		"type": "item"
 	},
 
+	"forms": {
+		"toResponseFileHandling": {
+			"identifier": "replace",
+			"pattern": "^(Line|Space)Separated$",
+			"replacement": "ParseArgsAs$1Separated"
+		}
+	},
+
 	"symbols": {
 		"ClassName": {
 			"type": "parameter",
@@ -51,30 +59,33 @@
 
 		"response-file": {
 			"type": "parameter",
-			"description": "Response file support. Command line arguments can be added to a response file and the response can be passed in as though each argument was manually typed at the commandline",
+			"description": "Response file support. A response file is a text file of command line arguments that users can pass as @file.rsp instead of typing each argument at the command line",
 			"datatype": "choice",
 			"choices": [
 				{
 					"choice": "Disabled",
-					"description": "Disabled",
-					"displayName": "Disabled - No response file support.",
-					"documentation": ""
+					"displayName": "Disabled",
+					"description": "No response file support"
 				},
 				{
-					"choice": "ParseArgsAsLineSeparated",
-					"description": "Line separated",
-					"displayName": "Line separated - Each argument is on a new line.",
-					"documentation": ""
+					"choice": "LineSeparated",
+					"displayName": "Line separated",
+					"description": "Each argument in the response file is on its own line"
 				},
 				{
-					"choice": "ParseArgsAsSpaceSeparated",
-					"description": "Space separated",
-					"displayName": "Space separated - All arguments are on a single line in separated by spaces.",
-					"documentation": ""
+					"choice": "SpaceSeparated",
+					"displayName": "Space separated",
+					"description": "All arguments in the response file are on a single line, separated by spaces"
 				}
 			],
-			"replaces": "ParseArgsAsSpaceSeparated",
-			"defaultValue": "ParseArgsAsLineSeparated"
+			"defaultValue": "LineSeparated"
+		},
+
+		"response-file-handling": {
+			"type": "derived",
+			"valueSource": "response-file",
+			"valueTransform": "toResponseFileHandling",
+			"replaces": "ParseArgsAsSpaceSeparated"
 		}
 	},
 	"primaryOutputs": [


### PR DESCRIPTION
**Stack 3/3** (base: `quickwin/20-third-party-notices`) — quick-win batch.

## Summary
Both halves of #49, in all three templates:
- **Shorter choice values**: `--response-file Disabled|LineSeparated|SpaceSeparated` instead of the raw enum member names (`ParseArgsAsLineSeparated`, ...). The code substitution moved to a **derived symbol** with a regex value transform (`^(Line|Space)Separated$` → `ParseArgsAs$1Separated`), so the short value still emits the correct `ResponseFileHandling` member into the generated code. (A derived symbol avoids the switch-generator's expression evaluator, which is unfriendly to hyphenated symbol names.)
- **Real descriptions/displayNames** on the parameter and each choice; empty `documentation` fields dropped.

Note: choice values are user-facing input, so anyone scripting `--response-file ParseArgsAsLineSeparated` against 0.5.0 will need the new shorter value — worth a CHANGELOG line at the next release.

## Verification
Packed + installed + instantiated each template with each choice; generated code carries the right enum member every time (e.g. `cwsubcmdetl --response-file LineSeparated` → `ResponseFileHandling.ParseArgsAsLineSeparated`).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)