### PR TITLE
Wire CancellationToken into all template commands for graceful Ctrl+C (#121)

### DIFF
--- a/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
+++ b/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
@@ -71,7 +71,8 @@ internal class SampleCommand
         SampleConfiguration configuration,
         IConsole console,
         IReporter reporter,
-        ILogger<SampleCommand> logger
+        ILogger<SampleCommand> logger,
+        CancellationToken cancellationToken
     )
     {
         logger.LogInformation("Starting {Command}", GetType().Name);
@@ -83,12 +84,19 @@ internal class SampleCommand
         {
             // TODO Validate command line arguments
 
-            // TODO Your code here
+            // TODO Your code here - pass cancellationToken to your async calls so
+            // Ctrl+C / host shutdown stops the command gracefully
             console.WriteLine("Hello world!");
             await Task.Yield(); // Simulate doing work
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Note You can use the reporter to write to the console
             reporter.Warn("Sample console warning");
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("{Command} was canceled", GetType().Name);
+            return ExitCode.Canceled;
         }
         catch (Exception e)
         {

--- a/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
+++ b/src/ConsoleAppTemplate/Content/Command/SampleCommand.cs
@@ -93,9 +93,9 @@ internal class SampleCommand
             // Note You can use the reporter to write to the console
             reporter.Warn("Sample console warning");
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e)
         {
-            logger.LogWarning("{Command} was canceled", GetType().Name);
+            logger.LogWarning(e, "{Command} was canceled", GetType().Name);
             return ExitCode.Canceled;
         }
         catch (Exception e)

--- a/src/ConsoleAppTemplate/Content/ExitCode.cs
+++ b/src/ConsoleAppTemplate/Content/ExitCode.cs
@@ -6,4 +6,5 @@ internal static class ExitCode
     internal const int Success = 0;
     internal const int UnhandledException = 10;
     internal const int ApplicationError = 11;
+    internal const int Canceled = 12;
 }

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -225,9 +225,9 @@ To configure a sub command, you will need to do the following:
 >**Tip**
 >
 >Add a `CancellationToken` parameter to `OnExecuteAsync` and pass it to your async calls —
-McMaster automatically wires it to Ctrl+C / host shutdown so your command stops gracefully.
-See `Command/SampleCommand.cs` for the pattern, including catching `OperationCanceledException`
-and returning `ExitCode.Canceled`.
+>McMaster automatically wires it to Ctrl+C / host shutdown so your command stops gracefully.
+>See `Command/SampleCommand.cs` for the pattern, including catching `OperationCanceledException`
+>and returning `ExitCode.Canceled`.
 
 1. Add properties to the class with the `[Argument]` and `[Option]` attributes the command line arguments to the class. 
 	```csharp 

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -221,6 +221,14 @@ To configure a sub command, you will need to do the following:
 	a. int OnExecute
 	a. Task OnExecuteAsync
 	a. Task&lt;int&gt; OnExecuteAsync
+
+>**Tip**
+>
+>Add a `CancellationToken` parameter to `OnExecuteAsync` and pass it to your async calls —
+McMaster automatically wires it to Ctrl+C / host shutdown so your command stops gracefully.
+See `Command/SampleCommand.cs` for the pattern, including catching `OperationCanceledException`
+and returning `ExitCode.Canceled`.
+
 1. Add properties to the class with the `[Argument]` and `[Option]` attributes the command line arguments to the class. 
 	```csharp 
 	internal class SampleCommand

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -57,7 +57,8 @@ internal class EtlSubCommandTemplate
     (
         IConsole console,
         ILoggerFactory loggerFactory,
-        ILogger<EtlSubCommandTemplate> logger
+        ILogger<EtlSubCommandTemplate> logger,
+        CancellationToken cancellationToken
     )
     {
         logger.LogDebug("Starting {Command}", GetType().Name);
@@ -94,9 +95,12 @@ internal class EtlSubCommandTemplate
             // TODO Create instances of the loader
             //var loader = new MyLoader< , Report>(loggerFactory.CreateLogger<MyLoader< ,Report>>());
 
-            // Execute the ETL process asynchronously
+            // Execute the ETL process asynchronously. Pass cancellationToken into
+            // your extractor/transformer/loader implementations so Ctrl+C / host
+            // shutdown stops the pipeline gracefully.
             // await ExecuteEtlAsync(extractor, transformer, loader, progress);
             await Task.Yield(); // Simulate doing work - remove once ExecuteEtlAsync above is uncommented
+            cancellationToken.ThrowIfCancellationRequested();
 
             logger.LogInformation("ETL process completed successfully.");
         }

--- a/src/SubCommandTemplate/Content/SubCommandTemplate.cs
+++ b/src/SubCommandTemplate/Content/SubCommandTemplate.cs
@@ -26,7 +26,8 @@ internal class SubCommandTemplate
     internal async Task<int> OnExecuteAsync
     (
         IConsole console,
-        ILogger<SubCommandTemplate> logger
+        ILogger<SubCommandTemplate> logger,
+        CancellationToken cancellationToken
     )
     {
         logger.LogDebug("Starting {Command}", GetType().Name);
@@ -37,8 +38,10 @@ internal class SubCommandTemplate
 
 
 
-            // TODO Your code here
+            // TODO Your code here - pass cancellationToken to your async calls so
+            // Ctrl+C / host shutdown stops the command gracefully
             await Task.Yield(); // Simulate doing work - remove once your code awaits something
+            cancellationToken.ThrowIfCancellationRequested();
 
         }
         catch (Exception e)


### PR DESCRIPTION
## Summary
- `OnExecuteAsync` in all three templates (`SampleCommand`, `SubCommandTemplate`, `EtlSubCommandTemplate`) now takes a `CancellationToken` — McMaster auto-binds it to the console cancel signal / host shutdown.
- `SampleCommand` demonstrates the full pattern: pass the token to async work, catch `OperationCanceledException`, return the new `ExitCode.Canceled` (12).
- The item templates carry the token with a TODO steering users to pass it into their own async calls (the ETL Abstractions interfaces are `IAsyncEnumerable`-based with no token parameters, so cancellation there belongs inside the extractor/loader implementations).
- Instructions.md documents the auto-wired token in the Sub Commands section.

## Verification
Release build clean (0 warnings under TWAE); `dotnet run -- sample ...` executes normally with the token parameter bound.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)