### PR TITLE
Automatically register [Command] classes as subcommands (#1)

### DIFF
--- a/src/ConsoleAppTemplate/Content/Framework/AutoRegisterCommandsConvention.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/AutoRegisterCommandsConvention.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.CommandLineUtils.Conventions;
+
+namespace ConsoleAppTemplate.Framework;
+
+/// <summary>
+/// Discovers every class in this assembly decorated with <see cref="CommandAttribute"/>
+/// and registers it as a subcommand of the root application, so new commands (for
+/// example ones added with <c>dotnet new cwsubcmd</c>) work without editing Program.cs.
+/// </summary>
+/// <remarks>
+/// The subcommand name is taken from <see cref="CommandAttribute.Name"/> when set;
+/// otherwise it is derived from the class name by removing a trailing "Command" and
+/// lower-casing the remainder (SampleCommand becomes "sample"). Commands already
+/// registered another way (for example via a [Subcommand] attribute on Program) are
+/// skipped, so explicit and automatic registration can coexist.
+/// </remarks>
+internal class AutoRegisterCommandsConvention : IConvention
+{
+    // The Register method is public (on this internal class) so the reflection
+    // lookup below needs no accessibility bypass (S3011).
+    private static readonly MethodInfo RegisterMethod = typeof(AutoRegisterCommandsConvention)
+        .GetMethod(nameof(Register), BindingFlags.Public | BindingFlags.Static)!;
+
+
+
+    public void Apply(ConventionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Only apply to the root command; without this guard the convention would
+        // re-run for every subcommand it registers and recurse forever.
+        if (context.ModelType != typeof(Program))
+        {
+            return;
+        }
+
+        var commandTypes = typeof(Program).Assembly
+            .GetTypes()
+            .Where
+            (
+                type => type is { IsClass: true, IsAbstract: false }
+                    && type != typeof(Program)
+                    && type.GetCustomAttribute<CommandAttribute>() is not null
+            );
+
+        foreach (var type in commandTypes)
+        {
+            var name = type.GetCustomAttribute<CommandAttribute>()!.Name ?? DeriveName(type.Name);
+
+            if (context.Application.Commands.Any(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            RegisterMethod
+                .MakeGenericMethod(type)
+                .Invoke(null, [context.Application, name]);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Derives the default subcommand name from a class name: a trailing "Command"
+    /// is removed and the remainder is lower-cased, e.g. SampleCommand -> "sample".
+    /// </summary>
+    private static string DeriveName(string typeName)
+    {
+        const string suffix = "Command";
+
+        var trimmed = typeName.EndsWith(suffix, StringComparison.Ordinal) && typeName.Length > suffix.Length
+            ? typeName[..^suffix.Length]
+            : typeName;
+
+        return trimmed.ToLowerInvariant();
+    }
+
+
+
+    public static void Register<TCommand>(CommandLineApplication application, string name) where TCommand : class
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        application.Command<TCommand>(name, _ => { });
+    }
+}

--- a/src/ConsoleAppTemplate/Content/Framework/AutoRegisterCommandsConvention.cs
+++ b/src/ConsoleAppTemplate/Content/Framework/AutoRegisterCommandsConvention.cs
@@ -6,8 +6,9 @@ namespace ConsoleAppTemplate.Framework;
 
 /// <summary>
 /// Discovers every class in this assembly decorated with <see cref="CommandAttribute"/>
-/// and registers it as a subcommand of the root application, so new commands (for
-/// example ones added with <c>dotnet new cwsubcmd</c>) work without editing Program.cs.
+/// (other than the root <see cref="Program"/> class itself) and registers it as a
+/// subcommand of the root application, so new commands (for example ones added with
+/// <c>dotnet new cwsubcmd</c>) work without editing Program.cs.
 /// </summary>
 /// <remarks>
 /// The subcommand name is taken from <see cref="CommandAttribute.Name"/> when set;
@@ -38,16 +39,17 @@ internal class AutoRegisterCommandsConvention : IConvention
 
         var commandTypes = typeof(Program).Assembly
             .GetTypes()
-            .Where
-            (
-                type => type is { IsClass: true, IsAbstract: false }
-                    && type != typeof(Program)
-                    && type.GetCustomAttribute<CommandAttribute>() is not null
-            );
+            .Where(type => type is { IsClass: true, IsAbstract: false } && type != typeof(Program))
+            .Select(type => (Type: type, Attribute: type.GetCustomAttribute<CommandAttribute>()))
+            .Where(candidate => candidate.Attribute is not null);
 
-        foreach (var type in commandTypes)
+        foreach (var (type, attribute) in commandTypes)
         {
-            var name = type.GetCustomAttribute<CommandAttribute>()!.Name ?? DeriveName(type.Name);
+            // An empty or whitespace Name on the attribute would register an
+            // unusable command - fall back to the derived name instead.
+            var name = string.IsNullOrWhiteSpace(attribute!.Name)
+                ? DeriveName(type.Name)
+                : attribute.Name;
 
             if (context.Application.Commands.Any(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase)))
             {

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -215,7 +215,13 @@ To configure a sub command, you will need to do the following:
 1. Create a class for the sub command in the Command folder
 1. You can name the class whatever you want, but it is recommended to name it a verb followed by the word Command. i.e. ExportCommand, FormatCommand, etc.
 1. Add the [Command] attribute to the class and set the Name and Description properties
-1. Add the [SubCommand] attribute to the Program class. i.e. `[Subcommand(typeof(SampleCommand))]`
+1. That's it for wiring - commands are **registered automatically**. Every class in the
+   assembly decorated with `[Command]` is discovered at startup and added as a subcommand
+   (see `Framework/AutoRegisterCommandsConvention.cs`). The subcommand name comes from the
+   `[Command]` attribute's `Name` when set, otherwise from the class name with a trailing
+   "Command" removed and lower-cased (ExportCommand becomes `export`). If you prefer
+   explicit registration, remove the `AddConvention` call in Program.cs Main and add
+   `[Subcommand(typeof(YourCommand))]` attributes to the Program class instead.
 1. Add one of the following methods to the class
 	a. void OnExecute
 	a. int OnExecute

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -216,7 +216,8 @@ To configure a sub command, you will need to do the following:
 1. You can name the class whatever you want, but it is recommended to name it a verb followed by the word Command. i.e. ExportCommand, FormatCommand, etc.
 1. Add the [Command] attribute to the class and set the Name and Description properties
 1. That's it for wiring - commands are **registered automatically**. Every class in the
-   assembly decorated with `[Command]` is discovered at startup and added as a subcommand
+   assembly decorated with `[Command]` - except the root `Program` class, which is the
+   application itself - is discovered at startup and added as a subcommand
    (see `Framework/AutoRegisterCommandsConvention.cs`). The subcommand name comes from the
    `[Command]` attribute's `Name` when set, otherwise from the class name with a trailing
    "Command" removed and lower-cased (ExportCommand becomes `export`). If you prefer

--- a/src/ConsoleAppTemplate/Content/Program.cs
+++ b/src/ConsoleAppTemplate/Content/Program.cs
@@ -27,9 +27,9 @@ namespace ConsoleAppTemplate
         ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated
     )]
     // Sub commands are discovered and registered automatically - every class in this
-    // assembly decorated with [Command] becomes a subcommand (see
-    // Framework/AutoRegisterCommandsConvention.cs). Just add a new command class (e.g.
-    // via 'dotnet new cwsubcmd') and it is picked up on the next run.
+    // assembly decorated with [Command], other than this Program class itself, becomes
+    // a subcommand (see Framework/AutoRegisterCommandsConvention.cs). Just add a new
+    // command class (e.g. via 'dotnet new cwsubcmd') and it is picked up on the next run.
     // TODO If you prefer explicit registration, remove the AddConvention call in Main
     // and list each command here instead:
     // [Subcommand(typeof(SampleCommand))]

--- a/src/ConsoleAppTemplate/Content/Program.cs
+++ b/src/ConsoleAppTemplate/Content/Program.cs
@@ -26,8 +26,13 @@ namespace ConsoleAppTemplate
         // TODO Specify response file handling. Default is disabled. See https://natemcmaster.github.io/CommandLineUtils/v3.0/api/McMaster.Extensions.CommandLineUtils.ResponseFileHandling.html
         ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated
     )]
-    [Subcommand(typeof(SampleCommand))]
-    // TODO Add additional sub commands here
+    // Sub commands are discovered and registered automatically - every class in this
+    // assembly decorated with [Command] becomes a subcommand (see
+    // Framework/AutoRegisterCommandsConvention.cs). Just add a new command class (e.g.
+    // via 'dotnet new cwsubcmd') and it is picked up on the next run.
+    // TODO If you prefer explicit registration, remove the AddConvention call in Main
+    // and list each command here instead:
+    // [Subcommand(typeof(SampleCommand))]
     internal class Program
     {
         private static async Task<int> Main(string[] args)
@@ -66,7 +71,11 @@ namespace ConsoleAppTemplate
 
                             ;
                     })
-                    .RunCommandLineApplicationAsync<Program>(args);
+                    .RunCommandLineApplicationAsync<Program>
+                    (
+                        args,
+                        application => application.Conventions.AddConvention(new AutoRegisterCommandsConvention())
+                    );
             }
             catch (Exception e)
             {

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -1,6 +1,10 @@
 ﻿// NOTE: This class depends on Wolfgang.Etl.Abstractions
 // TODO Please run the following in your project folder:
 //   dotnet add package Wolfgang.Etl.Abstractions
+//
+// NOTE: If your application was created from the Wolfgang Console App template this
+// command is registered automatically at startup (AutoRegisterCommandsConvention).
+// In an app without that convention, add [Subcommand(typeof(<this class>))] to Program.
 
 using System.ComponentModel.DataAnnotations;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -4,7 +4,7 @@
 //
 // NOTE: If your application was created from the Wolfgang Console App template this
 // command is registered automatically at startup (AutoRegisterCommandsConvention).
-// In an app without that convention, add [Subcommand(typeof(<this class>))] to Program.
+// In an app without that convention, add [Subcommand(typeof(EtlSubCommandTemplate))] to Program.
 
 using System.ComponentModel.DataAnnotations;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/SubCommandTemplate/Content/SubCommandTemplate.cs
+++ b/src/SubCommandTemplate/Content/SubCommandTemplate.cs
@@ -1,4 +1,7 @@
-﻿using McMaster.Extensions.CommandLineUtils;
+﻿// NOTE: If your application was created from the Wolfgang Console App template this
+// command is registered automatically at startup (AutoRegisterCommandsConvention).
+// In an app without that convention, add [Subcommand(typeof(<this class>))] to Program.
+using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 
 namespace {DefaultNamespace}.Command;

--- a/src/SubCommandTemplate/Content/SubCommandTemplate.cs
+++ b/src/SubCommandTemplate/Content/SubCommandTemplate.cs
@@ -1,6 +1,6 @@
 ﻿// NOTE: If your application was created from the Wolfgang Console App template this
 // command is registered automatically at startup (AutoRegisterCommandsConvention).
-// In an app without that convention, add [Subcommand(typeof(<this class>))] to Program.
+// In an app without that convention, add [Subcommand(typeof(SubCommandTemplate))] to Program.
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
**Stacked on #258** (shares Program.cs / item-template / Instructions.md edits).

## Summary
Implements the oldest open issue in the repo: commands no longer need manual `[Subcommand(typeof(...))]` wiring on Program.

- New `Framework/AutoRegisterCommandsConvention` — a McMaster `IConvention` that scans the entry assembly for `[Command]`-decorated classes and registers each as a subcommand. Wired in `Main` via the `RunCommandLineApplicationAsync` configure callback.
- Naming: `[Command].Name` when set, otherwise class name minus a trailing `Command`, lower-cased — `SampleCommand` → `sample`, identical to what the attribute path produced before.
- Explicitly-registered commands are skipped (both styles coexist); a root-only guard prevents recursion.
- `[Subcommand(typeof(SampleCommand))]` removed from Program.cs, kept as a commented opt-out example with a TODO.
- This also erases the classic `cwsubcmd` gotcha: **a generated subcommand class now works with zero Program.cs edits** — both item templates carry a note saying so.

## Verification (all in the generated environment — pack → install → `dotnet new cwconsole` → build/run)
- Generated project builds clean under analyzer defaults + Release TreatWarningsAsErrors (this round caught and fixed S3011 here, and S6667 on the #258 base)
- `--help` lists `sample`; `sample` executes with full DI (config binding, IConsole, IReporter, logger, CancellationToken) and argument validation
- Dropped a transient `EchoCommand.cs` into a build with **zero wiring**: appeared in `--help` as `echo` and executed

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)