### PR TITLE
Document SDK container publishing; close #125 as superseded

### DIFF
--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -16,7 +16,8 @@
 7. [Configuring Your App for Use with the Commandline](#configuring-your-app-for-use-with-the-commandline)  
 8. [Console Colors](#console-colors)  
 9. [Logging](#logging)  
-10. [Credits](#credits)  
+10. [Containerizing Your App](#containerizing-your-app)  
+11. [Credits](#credits)  
 
 
 # TODOs / Checklist
@@ -375,6 +376,31 @@ properties which will be written to the logs.
 
 
 
+
+
+# Containerizing Your App
+
+You do not need a Dockerfile to run this application as a container. The .NET SDK
+builds an OCI image directly from the project:
+
+```sh
+dotnet publish -c Release /t:PublishContainer
+```
+
+The image is created in your local container store (e.g. Docker), named after the
+project, using a `mcr.microsoft.com/dotnet/runtime` base image that matches your
+target framework. Customize it with csproj properties as needed:
+
+```xml
+<ContainerRepository>my-app</ContainerRepository>
+<ContainerImageTags>1.0.0;latest</ContainerImageTags>
+<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:8.0</ContainerBaseImage>
+```
+
+See [SDK container publishing](https://learn.microsoft.com/en-us/dotnet/core/containers/sdk-publish)
+for all options. If your CI/CD pipeline requires an explicit Dockerfile instead, the standard
+multi-stage .NET pattern is documented at
+[Containerize a .NET app](https://learn.microsoft.com/en-us/dotnet/core/docker/build-container).
 
 
 # Credits

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -387,14 +387,23 @@ builds an OCI image directly from the project:
 dotnet publish -c Release /t:PublishContainer
 ```
 
-The image is created in your local container store (e.g. Docker), named after the
-project, using a `mcr.microsoft.com/dotnet/runtime` base image that matches your
-target framework. Customize it with csproj properties as needed:
+>**Note**
+>
+>Publishing to the local container store requires a container engine (Docker or
+>Podman) to be installed and running - without one, `PublishContainer` fails.
+>Alternatively, push straight to a registry with `-p:ContainerRegistry=<registry>`,
+>which needs no local engine.
+
+The image is created in your local container store, named after the project, using a
+`mcr.microsoft.com/dotnet/runtime` base image that matches your target framework.
+Customize it with csproj properties as needed:
 
 ```xml
-<ContainerRepository>my-app</ContainerRepository>
-<ContainerImageTags>1.0.0;latest</ContainerImageTags>
-<ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:8.0</ContainerBaseImage>
+<PropertyGroup>
+    <ContainerRepository>my-app</ContainerRepository>
+    <ContainerImageTags>1.0.0;latest</ContainerImageTags>
+    <ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:8.0</ContainerBaseImage>
+</PropertyGroup>
 ```
 
 See [SDK container publishing](https://learn.microsoft.com/en-us/dotnet/core/containers/sdk-publish)


### PR DESCRIPTION
## Summary
Resolves #125 ("optional Dockerfile generation") by documenting the modern path instead of scaffolding files:

- Since .NET 8, the SDK builds OCI images directly — `dotnet publish -c Release /t:PublishContainer` — with a runtime base image matched to the target framework. That's Microsoft's recommended route for console apps and delivers what #125 wanted with zero new template surface and no base-image tags to keep in sync with the `framework` parameter.
- Instructions.md gains a **Containerizing Your App** section (+ TOC entry) with the publish command, the csproj customization properties, and links to the SDK container docs — plus a pointer to the standard multi-stage Dockerfile pattern for pipelines that require an explicit Dockerfile.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)