### PR TITLE
Fix item-template namespace auto-detection from the CLI (#262)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -333,14 +333,10 @@ jobs:
             ${{ matrix.sdk }}.x
             10.0.x
 
-      - name: Pack the console + subcommand templates
+      - name: Pack the console template
         # Packing is the repo's side of the workflow (the release pipeline does
         # it with the repo's SDK), so it deliberately runs on the newest SDK.
-        shell: bash
-        run: |
-          dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
-          dotnet pack src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
-          dotnet pack src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
+        run: dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
 
       - name: Pin consumer workspace to SDK ${{ matrix.sdk }}
         # Everything a USER does - dotnet new install, instantiate, build, run -
@@ -356,30 +352,12 @@ jobs:
           EOF
           cd smoke && echo "Consumer-side SDK in use: $(dotnet --version)"
 
-      - name: Install templates and instantiate a project
+      - name: Install template and instantiate a project
         shell: bash
         working-directory: ./smoke
         run: |
           dotnet new install ../smoke-packages/Wolfgang.Template.Console.*.nupkg
           dotnet new cwconsole -n SmokeApp -o ./smoke-app
-
-      - name: Add subcommands via the item templates
-        # Restore first: the item templates' namespace auto-detection binds to
-        # msbuild:RootNamespace, which only evaluates once the project is
-        # restored. This also exercises that cwsubcmd/cwsubcmdetl generate
-        # compilable code in a real project (regression guard for #262). The
-        # ETL subcommand needs Wolfgang.Etl.Abstractions at build time.
-        shell: bash
-        working-directory: ./smoke/smoke-app
-        run: |
-          dotnet restore
-          dotnet new cwsubcmd    --ClassName ExportCommand -o Command
-          dotnet new cwsubcmdetl --ClassName ImportCommand -o Command
-          dotnet add package Wolfgang.Etl.Abstractions
-          echo "Generated subcommand namespaces:"
-          grep -h '^namespace' Command/ExportCommand.cs Command/ImportCommand.cs
-          grep -q '^namespace SmokeApp\.Command;' Command/ExportCommand.cs || { echo "::error::cwsubcmd namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
-          grep -q '^namespace SmokeApp\.Command;' Command/ImportCommand.cs || { echo "::error::cwsubcmdetl namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
 
       - name: Build generated project (Release)
         working-directory: ./smoke/smoke-app
@@ -390,11 +368,7 @@ jobs:
         working-directory: ./smoke/smoke-app
         run: |
           dotnet run --project SmokeApp.csproj -c Release --no-build -- --version
-          # All three commands should be auto-registered (sample + the two we added).
-          help_output="$(dotnet run --project SmokeApp.csproj -c Release --no-build -- --help)"
-          for cmd in sample export import; do
-            echo "$help_output" | grep -q "$cmd" || { echo "::error::auto-registered '$cmd' subcommand missing from --help output"; exit 1; }
-          done
+          dotnet run --project SmokeApp.csproj -c Release --no-build -- --help | grep -q "sample" || { echo "::error::auto-registered 'sample' subcommand missing from --help output"; exit 1; }
 
   # ============================================================================
   # SECURITY: DevSkim static analysis

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -333,10 +333,14 @@ jobs:
             ${{ matrix.sdk }}.x
             10.0.x
 
-      - name: Pack the console template
+      - name: Pack the console + subcommand templates
         # Packing is the repo's side of the workflow (the release pipeline does
         # it with the repo's SDK), so it deliberately runs on the newest SDK.
-        run: dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
+        shell: bash
+        run: |
+          dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
+          dotnet pack src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
+          dotnet pack src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
 
       - name: Pin consumer workspace to SDK ${{ matrix.sdk }}
         # Everything a USER does - dotnet new install, instantiate, build, run -
@@ -352,12 +356,30 @@ jobs:
           EOF
           cd smoke && echo "Consumer-side SDK in use: $(dotnet --version)"
 
-      - name: Install template and instantiate a project
+      - name: Install templates and instantiate a project
         shell: bash
         working-directory: ./smoke
         run: |
           dotnet new install ../smoke-packages/Wolfgang.Template.Console.*.nupkg
           dotnet new cwconsole -n SmokeApp -o ./smoke-app
+
+      - name: Add subcommands via the item templates
+        # Restore first: the item templates' namespace auto-detection binds to
+        # msbuild:RootNamespace, which only evaluates once the project is
+        # restored. This also exercises that cwsubcmd/cwsubcmdetl generate
+        # compilable code in a real project (regression guard for #262). The
+        # ETL subcommand needs Wolfgang.Etl.Abstractions at build time.
+        shell: bash
+        working-directory: ./smoke/smoke-app
+        run: |
+          dotnet restore
+          dotnet new cwsubcmd    --ClassName ExportCommand -o Command
+          dotnet new cwsubcmdetl --ClassName ImportCommand -o Command
+          dotnet add package Wolfgang.Etl.Abstractions
+          echo "Generated subcommand namespaces:"
+          grep -h '^namespace' Command/ExportCommand.cs Command/ImportCommand.cs
+          grep -q '^namespace SmokeApp\.Command;' Command/ExportCommand.cs || { echo "::error::cwsubcmd namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
+          grep -q '^namespace SmokeApp\.Command;' Command/ImportCommand.cs || { echo "::error::cwsubcmdetl namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
 
       - name: Build generated project (Release)
         working-directory: ./smoke/smoke-app
@@ -368,7 +390,11 @@ jobs:
         working-directory: ./smoke/smoke-app
         run: |
           dotnet run --project SmokeApp.csproj -c Release --no-build -- --version
-          dotnet run --project SmokeApp.csproj -c Release --no-build -- --help | grep -q "sample" || { echo "::error::auto-registered 'sample' subcommand missing from --help output"; exit 1; }
+          # All three commands should be auto-registered (sample + the two we added).
+          help_output="$(dotnet run --project SmokeApp.csproj -c Release --no-build -- --help)"
+          for cmd in sample export import; do
+            echo "$help_output" | grep -q "$cmd" || { echo "::error::auto-registered '$cmd' subcommand missing from --help output"; exit 1; }
+          done
 
   # ============================================================================
   # SECURITY: DevSkim static analysis

--- a/src/ConsoleAppTemplate/Content/Instructions.md
+++ b/src/ConsoleAppTemplate/Content/Instructions.md
@@ -237,6 +237,14 @@ To configure a sub command, you will need to do the following:
 >See `Command/SampleCommand.cs` for the pattern, including catching `OperationCanceledException`
 >and returning `ExitCode.Canceled`.
 
+You can also scaffold a subcommand with the item templates: `dotnet new cwsubcmd` for a
+plain command or `dotnet new cwsubcmdetl` for an ETL command. Both detect your project's
+namespace automatically **as long as the project has been restored** (run `dotnet restore`
+or build once first) — the namespace binds to the project's `RootNamespace` via MSBuild,
+which is only available after restore. If you run the item template on a brand-new,
+un-restored project, the class is generated with a placeholder namespace (`MyApp.Command`);
+either restore first, or pass `--DefaultNamespaceFallback <YourRootNamespace>`.
+
 1. Add properties to the class with the `[Argument]` and `[Option]` attributes the command line arguments to the class. 
 	```csharp 
 	internal class SampleCommand

--- a/src/EtlSubCommandTemplate/Content/.template.config/template.json
+++ b/src/EtlSubCommandTemplate/Content/.template.config/template.json
@@ -35,9 +35,25 @@
 			"defaultValue": "EtlSubCommand"
 		},
 
-		"DefaultNamespace": {
+		"RootNamespaceBind": {
 			"type": "bind",
-			"binding": "msbuild:RootNamespace",
+			"binding": "msbuild:RootNamespace"
+		},
+
+		"DefaultNamespaceFallback": {
+			"type": "parameter",
+			"datatype": "text",
+			"description": "Root namespace for the generated command, used only when the project's namespace cannot be auto-detected (for example, running from the CLI before the project has been restored). The class is placed in <namespace>.Command. Tip: restore or build the project first and the namespace is detected automatically - no need to set this.",
+			"defaultValue": "MyApp"
+		},
+
+		"DefaultNamespace": {
+			"type": "generated",
+			"generator": "coalesce",
+			"parameters": {
+				"sourceVariableName": "RootNamespaceBind",
+				"fallbackVariableName": "DefaultNamespaceFallback"
+			},
 			"replaces": "{DefaultNamespace}"
 		},
 

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -72,9 +72,12 @@ internal class EtlSubCommandTemplate
             // TODO: Validate the command options here if necessary
 
             // TODO Build the pipeline and run it. Uncomment and fill in the types
-            // below. A Progress<Report> reporter surfaces item counts as it runs,
-            // and passing cancellationToken lets Ctrl+C / host shutdown stop the
-            // pipeline gracefully.
+            // below. A Progress<Report> reporter surfaces item counts as it runs.
+            // For graceful Ctrl+C / host shutdown, have your extractor/transformer/
+            // loader implementations observe cancellationToken - e.g. pass it into
+            // their constructors and check it while producing or consuming items.
+            // (The ETL abstraction methods themselves don't take a token, which is
+            // why ExecuteEtlAsync below doesn't forward one.)
             //
             // var progress = new Progress<Report>(report =>
             // {

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -60,7 +60,6 @@ internal class EtlSubCommandTemplate
     internal async Task<int> OnExecuteAsync
     (
         IConsole console,
-        ILoggerFactory loggerFactory,
         ILogger<EtlSubCommandTemplate> logger,
         CancellationToken cancellationToken
     )
@@ -78,6 +77,9 @@ internal class EtlSubCommandTemplate
             // their constructors and check it while producing or consuming items.
             // (The ETL abstraction methods themselves don't take a token, which is
             // why ExecuteEtlAsync below doesn't forward one.)
+            //
+            // To create the typed loggers below, add an `ILoggerFactory loggerFactory`
+            // parameter to this method - McMaster injects it by type.
             //
             // var progress = new Progress<Report>(report =>
             // {

--- a/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
+++ b/src/EtlSubCommandTemplate/Content/EtlSubCommandTemplate.cs
@@ -71,39 +71,28 @@ internal class EtlSubCommandTemplate
         {
             // TODO: Validate the command options here if necessary
 
-
-
-            // Create a progress reporter to report the current count of items processed
-            var progress = new Progress<Report>
-            (
-                report =>
-                {
-                    logger.LogDebug("Current count: {Count}", report.CurrentItemCount);
-                    console.WriteLine($"Current count: {report.CurrentItemCount}");
-                }
-            );
-
-
-            // TODO Create instances of the extractor
-            //var extractor = new MyExtractor< ,Report>(loggerFactory.CreateLogger<MyExtractor<, Report>>())
-            //{
-            //    MaximumItemCount = MaxItemCount ?? int.MaxValue,
-            //    SkipItemCount = SkipItemCount ?? 0
-            //};
-
-            
-            // TODO Create instances of the transformer
+            // TODO Build the pipeline and run it. Uncomment and fill in the types
+            // below. A Progress<Report> reporter surfaces item counts as it runs,
+            // and passing cancellationToken lets Ctrl+C / host shutdown stop the
+            // pipeline gracefully.
+            //
+            // var progress = new Progress<Report>(report =>
+            // {
+            //     logger.LogDebug("Current count: {Count}", report.CurrentItemCount);
+            //     console.WriteLine($"Current count: {report.CurrentItemCount}");
+            // });
+            //
+            // var extractor = new MyExtractor< , Report>(loggerFactory.CreateLogger<MyExtractor< , Report>>())
+            // {
+            //     MaximumItemCount = MaxItemCount ?? int.MaxValue,
+            //     SkipItemCount = SkipItemCount ?? 0
+            // };
             // var transformer = new MyTransformer< , , Report>(loggerFactory.CreateLogger<MyTransformer< , , Report>>());
-
-
-            // TODO Create instances of the loader
-            //var loader = new MyLoader< , Report>(loggerFactory.CreateLogger<MyLoader< ,Report>>());
-
-            // Execute the ETL process asynchronously. Pass cancellationToken into
-            // your extractor/transformer/loader implementations so Ctrl+C / host
-            // shutdown stops the pipeline gracefully.
+            // var loader = new MyLoader< , Report>(loggerFactory.CreateLogger<MyLoader< , Report>>());
+            //
             // await ExecuteEtlAsync(extractor, transformer, loader, progress);
-            await Task.Yield(); // Simulate doing work - remove once ExecuteEtlAsync above is uncommented
+
+            await Task.Yield(); // Simulate doing work - remove once the ETL pipeline above is uncommented
             cancellationToken.ThrowIfCancellationRequested();
 
             logger.LogInformation("ETL process completed successfully.");
@@ -121,7 +110,7 @@ internal class EtlSubCommandTemplate
     }
 
 
-    internal async Task ExecuteEtlAsync<TSource, TDestination, TProgress>
+    internal static Task ExecuteEtlAsync<TSource, TDestination, TProgress>
     (
         IExtractWithProgressAsync<TSource,TProgress> extractor,
         ITransformAsync<TSource, TDestination> transformer,
@@ -131,6 +120,6 @@ internal class EtlSubCommandTemplate
     {
         var item = extractor.ExtractAsync(reporter);
         var transformedItems = transformer.TransformAsync(item);
-        await loader.LoadAsync(transformedItems);
+        return loader.LoadAsync(transformedItems);
     }
 }

--- a/src/SubCommandTemplate/Content/.template.config/template.json
+++ b/src/SubCommandTemplate/Content/.template.config/template.json
@@ -35,9 +35,25 @@
 			"defaultValue": "SubCommand"
 		},
 
-		"DefaultNamespace": {
+		"RootNamespaceBind": {
 			"type": "bind",
-			"binding": "msbuild:RootNamespace",
+			"binding": "msbuild:RootNamespace"
+		},
+
+		"DefaultNamespaceFallback": {
+			"type": "parameter",
+			"datatype": "text",
+			"description": "Root namespace for the generated command, used only when the project's namespace cannot be auto-detected (for example, running from the CLI before the project has been restored). The class is placed in <namespace>.Command. Tip: restore or build the project first and the namespace is detected automatically - no need to set this.",
+			"defaultValue": "MyApp"
+		},
+
+		"DefaultNamespace": {
+			"type": "generated",
+			"generator": "coalesce",
+			"parameters": {
+				"sourceVariableName": "RootNamespaceBind",
+				"fallbackVariableName": "DefaultNamespaceFallback"
+			},
 			"replaces": "{DefaultNamespace}"
 		},
 


### PR DESCRIPTION
## Root cause
The item templates' `DefaultNamespace` symbol bound to `msbuild:RootNamespace`, which MSBuild can only evaluate **once the project is restored**. `dotnet new cwsubcmd` on an un-restored project failed the bind and emitted the literal `{DefaultNamespace}` token — invalid C#. (Verified: after `dotnet restore`, both our template and the built-in `class` template produce the correct namespace. The built-in `class` template avoids the silent-failure by requiring restore via a project-capability constraint and telling you to run restore.)

This is the bug that blocked `cwsubcmd`/`cwsubcmdetl` from joining the #85 smoke matrix.

## Fix
- **Both item templates coalesce**: `RootNamespaceBind` (auto-detected when the project is restored — VS *or* CLI) → `DefaultNamespaceFallback` parameter (default `MyApp`, overridable with `--DefaultNamespaceFallback`). Restored → correct namespace; un-restored → a valid placeholder instead of a broken token. Verified all three paths (restored/auto, un-restored/fallback, explicit override).
- **ETL template — three analyzer errors fixed** that only surface when the generated command is built in a real project under `TreatWarningsAsErrors`: `S2325`+`AsyncFixer01` (`ExecuteEtlAsync` is now `static` and returns the `Task` directly) and `S1481` (the unused `progress` reporter is folded into the commented scaffolding). These were latent — surfaced by actually building the generated project, the exact gap the smoke matrix closes.
- **Smoke matrix (#85) extended**: packs all three templates, restores the generated app, adds `cwsubcmd` + `cwsubcmdetl`, and builds — regression-guarding the item templates across OS × SDK. Asserts both namespaces auto-detect to `SmokeApp.Command` and all three commands (`sample`/`export`/`import`) auto-register.
- **Instructions.md** documents restore-first auto-detection and the fallback override.

## Verification (full generated environment)
Generated `cwconsole` app → `dotnet restore` → added `cwsubcmd` + `cwsubcmdetl` → `dotnet add package Wolfgang.Etl.Abstractions` → **Release build: 0 errors**; both subcommands land in `SmokeApp.Command`; `--help` lists all three auto-registered commands.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)