### PR TITLE
Fix generated-app Release build across the SDK matrix (CS9057 + CA2007)

### DIFF
--- a/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
+++ b/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
@@ -9,11 +9,13 @@
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
     <!-- Suppressions for intentional template scaffolding - remove entries as you
          work through the TODOs and adopt or delete the starter helpers:
-         MA0026/S1135 - the TODO comments are the template's guided setup checklist (see Instructions.md)
-         MA0004 - console apps have no SynchronizationContext; bare await is idiomatic here
-         S1144  - starter helpers (e.g. ConsoleColors) ship unreferenced until you use them
-         S125   - the guidance comments include example code blocks -->
-    <NoWarn>$(NoWarn);MA0026;S1135;MA0004;S1144;S125</NoWarn>
+         MA0026/S1135  - the TODO comments are the template's guided setup checklist (see Instructions.md)
+         MA0004/CA2007 - console apps have no SynchronizationContext, so ConfigureAwait(false)
+                         is unnecessary (Meziantou's MA0004 and the built-in .NET CA2007 are the
+                         same rule; CA2007 is enabled by default on newer SDKs)
+         S1144         - starter helpers (e.g. ConsoleColors) ship unreferenced until you use them
+         S125          - the guidance comments include example code blocks -->
+    <NoWarn>$(NoWarn);MA0026;S1135;MA0004;CA2007;S1144;S125</NoWarn>
     <!-- CS9057: McMaster.Extensions.CommandLineUtils ships a source generator built
          against the newest Roslyn (.NET 10 SDK). Building this net8.0 project with the
          .NET 8 SDK's older compiler skips that generator with a CS9057 warning, which

--- a/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
+++ b/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
@@ -7,23 +7,20 @@
     <Nullable>enable</Nullable>
     <!-- Treat warnings as errors in Release builds -->
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
-    <!-- Suppressions for intentional template scaffolding - remove entries as you
-         work through the TODOs and adopt or delete the starter helpers:
+    <!-- Warnings suppressed so the generated app builds cleanly under Release
+         TreatWarningsAsErrors. Remove the scaffolding entries as you work through the
+         TODOs and adopt or delete the starter helpers; the last two are permanent.
          MA0026/S1135  - the TODO comments are the template's guided setup checklist (see Instructions.md)
+         S1144         - starter helpers (e.g. ConsoleColors) ship unreferenced until you use them
+         S125          - the guidance comments include example code blocks
          MA0004/CA2007 - console apps have no SynchronizationContext, so ConfigureAwait(false)
                          is unnecessary (Meziantou's MA0004 and the built-in .NET CA2007 are the
                          same rule; CA2007 is enabled by default on newer SDKs)
-         S1144         - starter helpers (e.g. ConsoleColors) ship unreferenced until you use them
-         S125          - the guidance comments include example code blocks -->
-    <NoWarn>$(NoWarn);MA0026;S1135;MA0004;CA2007;S1144;S125</NoWarn>
-    <!-- CS9057: McMaster.Extensions.CommandLineUtils ships a source generator built
-         against the newest Roslyn (.NET 10 SDK). Building this net8.0 project with the
-         .NET 8 SDK's older compiler skips that generator with a CS9057 warning, which
-         TreatWarningsAsErrors would turn into a build failure. The template uses
-         reflection-based command parsing, not the generator, so skipping it is harmless;
-         suppress the warning so the app builds on the documented-minimum .NET 8 SDK.
-         On the .NET 10 SDK the generator runs normally and this suppression is a no-op. -->
-    <NoWarn>$(NoWarn);CS9057</NoWarn>
+         CS9057        - McMaster.Extensions.CommandLineUtils ships a source generator built
+                         against the newest Roslyn (.NET 10 SDK); the .NET 8 SDK's older compiler
+                         skips it with this warning. The template uses reflection-based command
+                         parsing, not the generator, so skipping it is harmless. No-op on .NET 10. -->
+    <NoWarn>$(NoWarn);MA0026;S1135;S1144;S125;MA0004;CA2007;CS9057</NoWarn>
 	<PackageVersion>0.1.0</PackageVersion>
 	<LangVersion>latest</LangVersion>
 	<Copyright>Copyright {copyright year} {author}</Copyright>

--- a/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
+++ b/src/ConsoleAppTemplate/Content/ConsoleAppTemplate.csproj
@@ -14,6 +14,14 @@
          S1144  - starter helpers (e.g. ConsoleColors) ship unreferenced until you use them
          S125   - the guidance comments include example code blocks -->
     <NoWarn>$(NoWarn);MA0026;S1135;MA0004;S1144;S125</NoWarn>
+    <!-- CS9057: McMaster.Extensions.CommandLineUtils ships a source generator built
+         against the newest Roslyn (.NET 10 SDK). Building this net8.0 project with the
+         .NET 8 SDK's older compiler skips that generator with a CS9057 warning, which
+         TreatWarningsAsErrors would turn into a build failure. The template uses
+         reflection-based command parsing, not the generator, so skipping it is harmless;
+         suppress the warning so the app builds on the documented-minimum .NET 8 SDK.
+         On the .NET 10 SDK the generator runs normally and this suppression is a no-op. -->
+    <NoWarn>$(NoWarn);CS9057</NoWarn>
 	<PackageVersion>0.1.0</PackageVersion>
 	<LangVersion>latest</LangVersion>
 	<Copyright>Copyright {copyright year} {author}</Copyright>


### PR DESCRIPTION
## The bugs (caught by the smoke matrix on its first real run)
The #85 smoke matrix went live on `main` and failed every open PR by catching two real, SDK-dependent build breaks in the generated app — both amplified by the template's Release `TreatWarningsAsErrors`. Local dev used the .NET 10 SDK and never hit either; the matrix (which pins each SDK under test) did. Exactly the ship-broken-to-users class it exists to catch.

1. **CS9057 (.NET 8 SDK):** McMaster.CommandLineUtils 5.1.0 ships a source generator built against the newest Roslyn (.NET 10 SDK). Building the net8.0 app with the .NET 8 SDK's older compiler skips the generator with a CS9057 warning → TWEA → build failure. The template uses reflection-based command parsing, not the generator, so skipping it is harmless (verified: builds and runs on SDK 8).
2. **CA2007 (all SDKs, esp. 9/10):** the built-in `ConfigureAwait` analyzer — the .NET twin of Meziantou's MA0004, which the template already suppresses. Console apps have no SynchronizationContext, so `ConfigureAwait(false)` is unnecessary; newer SDKs enable CA2007 by default → TWEA → build failure.

## Fix
Add `CS9057` and `CA2007` to the generated project's `<NoWarn>` (CA2007 sits alongside the existing MA0004 with a shared rationale). Both are non-destructive: on the .NET 10 SDK the generator runs and CS9057 is a no-op; CA2007 is a permanent console-app false positive.

## Why a focused PR
This reddens every open PR's smoke matrix and is independent of the other in-flight work, so it's isolated here to un-block `main` fast (no protected files → no admin bypass). #267 and the Dependabot PRs go green once rebased on the fixed `main`.

## Verification
Every matrix leg reported only these two codes (CS9057 on SDK 8, CA2007 across 8/9/10); local SDK-8 build with the CS9057 fix: 0 errors. This push adds the CA2007 suppression to clear the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)