### PR TITLE
pr.yaml: add item-template steps to the smoke matrix (split from #267)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -333,10 +333,14 @@ jobs:
             ${{ matrix.sdk }}.x
             10.0.x
 
-      - name: Pack the console template
+      - name: Pack the console + subcommand templates
         # Packing is the repo's side of the workflow (the release pipeline does
         # it with the repo's SDK), so it deliberately runs on the newest SDK.
-        run: dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
+        shell: bash
+        run: |
+          dotnet pack src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj --configuration Release --output ./smoke-packages
+          dotnet pack src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
+          dotnet pack src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj --configuration Release --output ./smoke-packages
 
       - name: Pin consumer workspace to SDK ${{ matrix.sdk }}
         # Everything a USER does - dotnet new install, instantiate, build, run -
@@ -352,12 +356,30 @@ jobs:
           EOF
           cd smoke && echo "Consumer-side SDK in use: $(dotnet --version)"
 
-      - name: Install template and instantiate a project
+      - name: Install templates and instantiate a project
         shell: bash
         working-directory: ./smoke
         run: |
           dotnet new install ../smoke-packages/Wolfgang.Template.Console.*.nupkg
           dotnet new cwconsole -n SmokeApp -o ./smoke-app
+
+      - name: Add subcommands via the item templates
+        # Restore first: the item templates' namespace auto-detection binds to
+        # msbuild:RootNamespace, which only evaluates once the project is
+        # restored. This also exercises that cwsubcmd/cwsubcmdetl generate
+        # compilable code in a real project (regression guard for #262). The
+        # ETL subcommand needs Wolfgang.Etl.Abstractions at build time.
+        shell: bash
+        working-directory: ./smoke/smoke-app
+        run: |
+          dotnet restore
+          dotnet new cwsubcmd    --ClassName ExportCommand -o Command
+          dotnet new cwsubcmdetl --ClassName ImportCommand -o Command
+          dotnet add package Wolfgang.Etl.Abstractions
+          echo "Generated subcommand namespaces:"
+          grep -h '^namespace' Command/ExportCommand.cs Command/ImportCommand.cs
+          grep -q '^namespace SmokeApp\.Command;' Command/ExportCommand.cs || { echo "::error::cwsubcmd namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
+          grep -q '^namespace SmokeApp\.Command;' Command/ImportCommand.cs || { echo "::error::cwsubcmdetl namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
 
       - name: Build generated project (Release)
         working-directory: ./smoke/smoke-app
@@ -368,7 +390,11 @@ jobs:
         working-directory: ./smoke/smoke-app
         run: |
           dotnet run --project SmokeApp.csproj -c Release --no-build -- --version
-          dotnet run --project SmokeApp.csproj -c Release --no-build -- --help | grep -q "sample" || { echo "::error::auto-registered 'sample' subcommand missing from --help output"; exit 1; }
+          # All three commands should be auto-registered (sample + the two we added).
+          help_output="$(dotnet run --project SmokeApp.csproj -c Release --no-build -- --help)"
+          for cmd in sample export import; do
+            echo "$help_output" | grep -q "$cmd" || { echo "::error::auto-registered '$cmd' subcommand missing from --help output"; exit 1; }
+          done
 
   # ============================================================================
   # SECURITY: DevSkim static analysis

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -375,7 +375,9 @@ jobs:
           dotnet restore
           dotnet new cwsubcmd    --ClassName ExportCommand -o Command
           dotnet new cwsubcmdetl --ClassName ImportCommand -o Command
-          dotnet add package Wolfgang.Etl.Abstractions
+          # Pin the version so an upstream release can't make the matrix
+          # non-deterministic (fail a PR unrelated to template changes).
+          dotnet add package Wolfgang.Etl.Abstractions --version 0.15.0
           echo "Generated subcommand namespaces:"
           grep -h '^namespace' Command/ExportCommand.cs Command/ImportCommand.cs
           grep -q '^namespace SmokeApp\.Command;' Command/ExportCommand.cs || { echo "::error::cwsubcmd namespace not auto-detected (expected 'SmokeApp.Command')"; exit 1; }
@@ -391,9 +393,12 @@ jobs:
         run: |
           dotnet run --project SmokeApp.csproj -c Release --no-build -- --version
           # All three commands should be auto-registered (sample + the two we added).
+          # Match command-list lines ("  <name>   <description>") anchored at the
+          # start rather than a bare substring, so a command name appearing inside a
+          # description can't produce a false positive.
           help_output="$(dotnet run --project SmokeApp.csproj -c Release --no-build -- --help)"
           for cmd in sample export import; do
-            echo "$help_output" | grep -q "$cmd" || { echo "::error::auto-registered '$cmd' subcommand missing from --help output"; exit 1; }
+            echo "$help_output" | grep -qE "^[[:space:]]+${cmd}([[:space:]]|\$)" || { echo "::error::auto-registered '$cmd' subcommand missing from the --help command list"; exit 1; }
           done
 
   # ============================================================================


### PR DESCRIPTION
## What
Extracts the `.github/workflows/pr.yaml` change out of #267 into its own PR, so #267 carries only template-content changes.

The smoke matrix (added in #261) is extended to also exercise the **item templates**: it now packs all three template packages, restores the generated app, adds `cwsubcmd` + `cwsubcmdetl`, builds, and asserts both subcommand namespaces auto-detect to `SmokeApp.Command` and all three commands (`sample`/`export`/`import`) auto-register. This is the regression guard for the #262 namespace fix.

## Why split it out
#267 was sitting at `BLOCKED` on `CodeQL: neutral` (the code-scanning ruleset rule — this template-pack repo has no analyzable app code, so CodeQL produces no SARIF). Isolating the workflow change here lets #267 contain only `.cs`/`.json`/`.md` template content, which should let its CodeQL analysis behave like #268's (`success`) and merge normally. It also keeps this one-file workflow change reviewable on its own.

Note: this repo's `Detect .NET Projects` guard does **not** protect `.github/workflows/*` (only root config files + `*.globalconfig`/`*.ruleset`), so the guard won't fire here — but this PR may still show `CodeQL: neutral`, in which case it needs an admin-bypass merge like the ruleset situation on #267.

Part of #262 (the item-template fix is #267).

🤖 Generated with [Claude Code](https://claude.com/claude-code)