### PR TITLE
ci: add ReSharper InspectCode job to pr.yaml (#235)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -402,6 +402,82 @@ jobs:
           done
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode, parallel to the other jobs
+  # (issue #235). Runs concurrently (needs: detect-projects only) so it doesn't
+  # extend wall-clock. Inspects the console-app template's Content project - the
+  # real, compilable C# users receive - via src/ConsoleAppTemplate.sln. (The
+  # item templates carry {DefaultNamespace} placeholder tokens, so they aren't a
+  # compilable project and can't be inspected here.) SARIF uploads to GitHub
+  # Code Scanning; error-severity findings fail the job, warnings surface but
+  # don't gate (tune the noise floor via a root .DotSettings later).
+  # Synced from the canonical repo-template job; adapted for this repo's
+  # under-src solution (no root .sln/.slnx).
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        # This repo has no root solution - the solution lives at
+        # src/ConsoleAppTemplate.sln. Pass it explicitly (a bare dotnet
+        # restore/build would fail with MSB1003).
+        run: |
+          dotnet restore src/ConsoleAppTemplate.sln
+          dotnet build src/ConsoleAppTemplate.sln -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          SLN=src/ConsoleAppTemplate.sln
+          if [ ! -f "$SLN" ]; then
+            echo "::error::$SLN not found — InspectCode needs the solution to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # SECURITY: DevSkim static analysis
   # ============================================================================
   security-scan:


### PR DESCRIPTION
## Summary
Fans out the canonical `inspectcode` job from repo-template (which landed it first, per the issue's plan) into this repo. It runs in parallel with the other jobs (`needs: detect-projects` only, no serial dependency), inspects the console-app template's **Content project** — the real, compilable C# users receive — via `src/ConsoleAppTemplate.sln`, and uploads SARIF to GitHub Code Scanning (Security tab + inline PR annotations). Error-severity findings fail the job; warnings surface but don't gate.

## Adaptation for this repo
The canonical job assumes a **root** solution. This template-pack repo has none — the solution is `src/ConsoleAppTemplate.sln`. So the Restore+Build step and the `jb inspectcode` invocation both target that path explicitly (a bare `dotnet restore`/`build` at root fails with MSB1003, the same fix applied to release.yaml/docfx.yaml earlier this cycle).

## Verified locally
Ran the tool against `src/ConsoleAppTemplate.sln`: **40 findings, all warning-severity, 0 error → the job passes green.** Breakdown:
- 38 × `NotAccessedField.Compiler` — the `ConsoleColors` starter helper's unreferenced color-code fields (intentional scaffolding; the same concern already suppressed via `S1144` in the csproj).
- 1 × `RedundantUsingDirective`, 1 × `UnusedAutoPropertyAccessor.Global`.

These are candidates for a future `.DotSettings` noise-floor profile (Step 2 in the issue, deferred — repo-template has none yet either). They're informational in Code Scanning and don't block merge.

## Not in this PR (owner actions)
- **Branch-ruleset**: adding "ReSharper InspectCode" to the required-status-checks on `main` (issue Step 3) is a ruleset change and yours to make. Until then the job runs and self-gates on errors, but isn't a merge requirement.
- **`.DotSettings` noise floor** (Step 2): deferred, pending the canonical baseline in repo-template.

## Coverage note
InspectCode analyzes the cwconsole Content project (real code). The **item templates** (`cwsubcmd`/`cwsubcmdetl`) carry `{DefaultNamespace}` placeholder tokens, so they aren't a compilable project and can't be inspected here — a limitation inherent to template-pack repos.

Part of #235 (workflow step). Leaving the issue open for the `.DotSettings` + ruleset steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)