### PR TITLE
docs: add Architecture Decision Records (#218)

### DIFF
--- a/docs/adr/0001-release-scoped-treatwarningsaserrors.md
+++ b/docs/adr/0001-release-scoped-treatwarningsaserrors.md
@@ -1,0 +1,37 @@
+# 0001 — Release-scoped TreatWarningsAsErrors in generated projects
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+The generated console app ships a curated analyzer set (AsyncFixer, Meziantou,
+Roslynator, SonarAnalyzer) to hold users to a quality bar. For that bar to have
+teeth, warnings must fail the build — but doing so in *Debug* would make everyday
+development miserable (every in-progress TODO breaks the build).
+
+A generated project also ships **no `.editorconfig`**, so it inherits whatever
+analyzer severities the building SDK enables by default. Those defaults **drift
+between SDK versions**, so "warnings as errors" turns any such drift into a build
+break for the user — on an SDK the template author never tested.
+
+## Decision
+
+Enable `TreatWarningsAsErrors` **only for Release** builds
+(`Condition="'$(Configuration)' == 'Release'"`), and pin the known
+false-positives / intentional-scaffolding warnings in a single `<NoWarn>` in the
+generated csproj: `MA0026;S1135;S1144;S125;MA0004;CA2007;CS9057`. Each entry has
+a documented reason (guided-setup TODOs, unreferenced starter helpers, example
+code in comments, ConfigureAwait-in-a-console-app, the McMaster source-generator
+compiler-version mismatch on older SDKs).
+
+## Consequences
+
+- Debug builds stay warning-tolerant; Release enforces the bar. CI builds Release,
+  so the gate is real without blocking local iteration.
+- The `NoWarn` list is a maintenance surface: new SDKs can enable new default
+  rules that break generated apps. The **generated-project smoke matrix** (ADR
+  0004) is the safety net that catches these across OS × SDK before users hit them
+  — it has already caught CS9057 (.NET 8 SDK), CA2007 (newer SDKs), and RCS1163.
+- Users are told, in a csproj comment, to remove the scaffolding entries as they
+  work through the TODOs.

--- a/docs/adr/0002-automatic-command-registration.md
+++ b/docs/adr/0002-automatic-command-registration.md
@@ -1,0 +1,38 @@
+# 0002 — Automatic command registration via an IConvention
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+McMaster.Extensions.CommandLineUtils registers subcommands through
+`[Subcommand(typeof(T))]` attributes on the root command. That means every new
+command a user adds — including one scaffolded with `dotnet new cwsubcmd` —
+required a manual edit to `Program.cs` to wire it up. That extra step was easy to
+forget and was a long-standing papercut (the `cwsubcmd` gotcha).
+
+## Decision
+
+Ship `Framework/AutoRegisterCommandsConvention` — a McMaster `IConvention` that
+scans the entry assembly for `[Command]`-decorated classes (excluding the root
+`Program`) and registers each as a subcommand. `Program.cs` wires it via the
+`RunCommandLineApplicationAsync` configure callback and drops the explicit
+`[Subcommand(...)]` attribute (kept as a commented opt-out).
+
+The subcommand name comes from `[Command].Name` when set, otherwise from the
+class name with a trailing `Command` removed and lower-cased
+(`SampleCommand` → `sample`) — identical to McMaster's previous behavior, so no
+observable change for existing commands.
+
+## Consequences
+
+- New commands work with **zero `Program.cs` edits** — add a `[Command]` class
+  (or run `dotnet new cwsubcmd`) and it's registered on the next run. The
+  item-template comments say so.
+- Explicitly-registered commands are skipped, so both styles coexist; a root-only
+  guard prevents the convention recursing into the subcommands it registers.
+- Registration is now reflection-at-startup rather than compile-time attributes.
+  For a CLI app this cost is negligible; it is noted here because it is a
+  deliberate trade (convenience over an attribute the reader can see).
+- Users who prefer explicit wiring remove the `AddConvention` call and use
+  `[Subcommand]` — documented in `Instructions.md`.

--- a/docs/adr/0003-item-template-namespace-auto-detection.md
+++ b/docs/adr/0003-item-template-namespace-auto-detection.md
@@ -1,0 +1,35 @@
+# 0003 — Item-template namespace auto-detection with a coalesce fallback
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+The `cwsubcmd` / `cwsubcmdetl` item templates need to place the generated class
+in the containing project's namespace (`<RootNamespace>.Command`). The natural
+mechanism is a `bind` symbol to `msbuild:RootNamespace`. But that bind is only
+evaluable once the project has been **restored** — MSBuild can't read the
+property otherwise. Running `dotnet new cwsubcmd` on a freshly-created,
+un-restored project failed the bind and emitted the literal `{DefaultNamespace}`
+token — invalid C# that wouldn't compile. (The built-in `dotnet new class`
+template sidesteps this by *requiring* restore via a project-capability
+constraint.)
+
+## Decision
+
+Keep the `msbuild:RootNamespace` bind (it is correct when it resolves, in both
+Visual Studio and a restored CLI project) but wrap it in a `coalesce` generated
+symbol: `RootNamespaceBind` → `DefaultNamespaceFallback` parameter (default
+`MyApp`, overridable with `--DefaultNamespaceFallback`). Restored → the real
+namespace; un-restored → a valid placeholder instead of a broken token.
+
+## Consequences
+
+- Visual Studio and restored-CLI usage get the correct namespace automatically.
+- Un-restored CLI usage produces compilable code (a placeholder namespace the
+  user can fix, or override up-front) rather than a syntax error.
+- `Instructions.md` documents "restore first for auto-detection, or pass
+  `--DefaultNamespaceFallback`."
+- The generated subcommand's compilation is guarded by the smoke matrix (ADR
+  0004), which restores the app and builds the added subcommands — this is where
+  the original bug, and later a latent `RCS1163`, were caught.

--- a/docs/adr/0004-template-pack-ci-adaptations.md
+++ b/docs/adr/0004-template-pack-ci-adaptations.md
@@ -1,7 +1,7 @@
 # 0004 — Template-pack CI/release adaptations
 
 - **Status:** Accepted
-- **Date:** 2026-07-09
+- **Date:** 2026-07-09 (amended 2026-07-11: added decision 5, the PR trigger)
 
 ## Context
 
@@ -31,6 +31,16 @@ Adapt the canonical workflows to the template-pack shape rather than fork them:
    across OS × SDK. This is the only place the generated app is exercised the way
    a user would, in the environment a user gets (no `.editorconfig` → analyzer
    defaults; the user's SDK).
+5. **PR trigger — `pull_request`, not `pull_request_target`.** The canonical
+   `pr.yaml` uses `pull_request_target` and a fork-safety apparatus (explicit
+   `refs/pull/*/head` checkouts, fetching config files from `main`, and a
+   "protected configuration file" guard) whose entire purpose is to run untrusted
+   **fork** PRs safely. This repo's PRs come from same-repo branches (single
+   maintainer), so that model is complexity with no benefit — and it costs real
+   friction (a `dangerous-triggers` suppression, protected-file-PR splits, and CI
+   validating `main`'s config instead of the PR's). We switched to plain
+   `pull_request` and removed the fork-only apparatus, keeping every job and its
+   name (so the branch ruleset's required checks still match).
 
 ## Consequences
 
@@ -42,3 +52,7 @@ Adapt the canonical workflows to the template-pack shape rather than fork them:
   minimum. See ADR 0001.
 - Coverage/perf/mutation-style CI that presumes a test suite or benchmarkable code
   is **not applicable** to this repo and belongs in the code-bearing repos.
+- Decision 5 is a deliberate *divergence* from canonical (not just an adaptation):
+  the `pull_request` trigger is the right default for a single-maintainer repo, but
+  a repo that accepts fork PRs should keep `pull_request_target` and the fork-safety
+  apparatus. Re-syncing `pr.yaml` from `repo-template` must preserve this choice.

--- a/docs/adr/0004-template-pack-ci-adaptations.md
+++ b/docs/adr/0004-template-pack-ci-adaptations.md
@@ -1,0 +1,44 @@
+# 0004 — Template-pack CI/release adaptations
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+This repository uses the fleet's canonical `pr.yaml` / `release.yaml`, which were
+written for **library/application** repos: they assume a root solution, a test
+suite with a coverage gate, and a DocFX site. This repo is a `dotnet new`
+**template pack** — the solution lives at `src/ConsoleAppTemplate.sln`, there are
+no test projects, and `docfx_project/` is a placeholder. Running the canonical
+workflows unchanged produced hard failures (MSB1003 from bare `dotnet restore` at
+root; "release requires tests"; a docs-deploy crash on a missing `docfx.json`).
+
+## Decision
+
+Adapt the canonical workflows to the template-pack shape rather than fork them:
+
+1. **Solution path** — every `dotnet restore/build/test` targets
+   `src/ConsoleAppTemplate.sln` explicitly (no root solution exists).
+2. **No-tests tolerance** — the release test + coverage-gate steps *skip with a
+   notice* when no `*Test*.csproj` exists, instead of hard-failing. The hard
+   failure is preserved for repos that do have tests.
+3. **Conditional docs** — `validate-release` emits a `has-docfx` output and the
+   docs-deploy job is gated on it, so a placeholder `docfx_project/` doesn't crash
+   the release.
+4. **Generated-project smoke matrix** — because the template's real "product" is
+   the code it *generates* (which the repo itself never compiles as an app), a
+   matrix job packs the templates, instantiates a project, and builds+runs it
+   across OS × SDK. This is the only place the generated app is exercised the way
+   a user would, in the environment a user gets (no `.editorconfig` → analyzer
+   defaults; the user's SDK).
+
+## Consequences
+
+- The workflows stay recognizably canonical (easy to re-sync from `repo-template`)
+  while working for a repo with no root solution, no tests, and no docs site.
+- The smoke matrix is load-bearing: it has caught multiple ship-broken-to-users
+  bugs invisible to local dev (a C# 13-only escape breaking the .NET 8 SDK,
+  CS9057, CA2007, RCS1163), because local dev used a newer SDK than the documented
+  minimum. See ADR 0001.
+- Coverage/perf/mutation-style CI that presumes a test suite or benchmarkable code
+  is **not applicable** to this repo and belongs in the code-bearing repos.

--- a/docs/adr/0004-template-pack-ci-adaptations.md
+++ b/docs/adr/0004-template-pack-ci-adaptations.md
@@ -1,21 +1,26 @@
 # 0004 — Template-pack CI/release adaptations
 
 - **Status:** Accepted
-- **Date:** 2026-07-09 (amended 2026-07-11: added decision 5, the PR trigger)
+- **Date:** 2026-07-09
 
 ## Context
 
-This repository uses the fleet's canonical `pr.yaml` / `release.yaml`, which were
-written for **library/application** repos: they assume a root solution, a test
-suite with a coverage gate, and a DocFX site. This repo is a `dotnet new`
+This repository started from the fleet's canonical `pr.yaml` / `release.yaml`,
+which were written for **library/application** repos: they assume a root solution,
+a test suite with a coverage gate, and a DocFX site. This repo is a `dotnet new`
 **template pack** — the solution lives at `src/ConsoleAppTemplate.sln`, there are
 no test projects, and `docfx_project/` is a placeholder. Running the canonical
 workflows unchanged produced hard failures (MSB1003 from bare `dotnet restore` at
 root; "release requires tests"; a docs-deploy crash on a missing `docfx.json`).
 
+This ADR covers the **adaptations** that keep the build/release pipeline working
+for a template pack while staying close to canonical. (`pr.yaml` later diverged
+further, in a way that is *not* just an adaptation — see [ADR 0005](0005-pr-trigger-pull-request.md).)
+
 ## Decision
 
-Adapt the canonical workflows to the template-pack shape rather than fork them:
+Adapt the canonical build/release steps to the template-pack shape rather than
+fork them:
 
 1. **Solution path** — every `dotnet restore/build/test` targets
    `src/ConsoleAppTemplate.sln` explicitly (no root solution exists).
@@ -31,28 +36,18 @@ Adapt the canonical workflows to the template-pack shape rather than fork them:
    across OS × SDK. This is the only place the generated app is exercised the way
    a user would, in the environment a user gets (no `.editorconfig` → analyzer
    defaults; the user's SDK).
-5. **PR trigger — `pull_request`, not `pull_request_target`.** The canonical
-   `pr.yaml` uses `pull_request_target` and a fork-safety apparatus (explicit
-   `refs/pull/*/head` checkouts, fetching config files from `main`, and a
-   "protected configuration file" guard) whose entire purpose is to run untrusted
-   **fork** PRs safely. This repo's PRs come from same-repo branches (single
-   maintainer), so that model is complexity with no benefit — and it costs real
-   friction (a `dangerous-triggers` suppression, protected-file-PR splits, and CI
-   validating `main`'s config instead of the PR's). We switched to plain
-   `pull_request` and removed the fork-only apparatus, keeping every job and its
-   name (so the branch ruleset's required checks still match).
 
 ## Consequences
 
-- The workflows stay recognizably canonical (easy to re-sync from `repo-template`)
-  while working for a repo with no root solution, no tests, and no docs site.
+- `release.yaml` and the shared build steps stay close to canonical (still
+  re-syncable from `repo-template`) while working for a repo with no root solution,
+  no tests, and no docs site.
 - The smoke matrix is load-bearing: it has caught multiple ship-broken-to-users
   bugs invisible to local dev (a C# 13-only escape breaking the .NET 8 SDK,
   CS9057, CA2007, RCS1163), because local dev used a newer SDK than the documented
   minimum. See ADR 0001.
 - Coverage/perf/mutation-style CI that presumes a test suite or benchmarkable code
   is **not applicable** to this repo and belongs in the code-bearing repos.
-- Decision 5 is a deliberate *divergence* from canonical (not just an adaptation):
-  the `pull_request` trigger is the right default for a single-maintainer repo, but
-  a repo that accepts fork PRs should keep `pull_request_target` and the fork-safety
-  apparatus. Re-syncing `pr.yaml` from `repo-template` must preserve this choice.
+- These are *adaptations*, not a fork — the build/release workflows remain
+  recognizably canonical. The one place that is a genuine fork is `pr.yaml`'s
+  trigger and fork-safety model, split out into [ADR 0005](0005-pr-trigger-pull-request.md).

--- a/docs/adr/0005-pr-trigger-pull-request.md
+++ b/docs/adr/0005-pr-trigger-pull-request.md
@@ -1,0 +1,55 @@
+# 0005 — `pr.yaml` diverges from canonical: `pull_request`, no fork-safety apparatus
+
+- **Status:** Accepted
+- **Date:** 2026-07-11
+
+## Context
+
+The canonical `pr.yaml` (adapted for this repo in [ADR 0004](0004-template-pack-ci-adaptations.md))
+triggers on **`pull_request_target`** and carries a fork-safety apparatus whose
+entire purpose is to run untrusted **fork** PRs without leaking secrets:
+
+- every checkout uses an explicit `ref: refs/pull/<n>/head`,
+- a step fetches the protected config files (`.editorconfig`, `Directory.Build.props`,
+  …) from `main` so a PR can't override them,
+- a "Detect protected configuration file changes" guard **fails** the run if a PR
+  touches those files.
+
+This repo's PRs come from **same-repo branches (single maintainer)**, not forks.
+So the fork model is complexity with no benefit — and it costs real, recurring
+friction:
+
+- `pull_request_target` is a dangerous trigger that the workflow-security audit
+  (zizmor) flags, forcing an explicit `# zizmor: ignore[dangerous-triggers]`;
+- the protected-file guard means any PR that legitimately edits a workflow or
+  config file has to be split into a separate admin-bypass PR;
+- CI validates **`main`'s** copy of the config, not the PR's — so a PR's own
+  workflow/config changes are never actually exercised before merge.
+
+## Decision
+
+Switch `pr.yaml` to plain **`pull_request`** and remove the fork-only apparatus:
+
+- drop the explicit `refs/pull/<n>/head` checkouts (the default ref under
+  `pull_request` already checks out the PR),
+- drop the "fetch trusted configuration files from `main`" steps,
+- drop the "Detect protected configuration file changes" guard (its premise —
+  "CI uses `main`'s version to prevent bypasses" — is *false* under `pull_request`,
+  which tests the PR's own files).
+
+Keep **every job and its name** so the branch ruleset's required status checks
+still match, and SHA-pin the actions. This is a deliberate **divergence** from the
+canonical workflow, not an adaptation.
+
+## Consequences
+
+- Simpler `pr.yaml`; PR checks run against the PR's own code and config (what you
+  actually want to validate before merge).
+- The dangerous trigger is gone, so zizmor passes with no suppression, and
+  workflow/config PRs no longer need protected-file splits.
+- **Re-syncing `pr.yaml` from `repo-template` must NOT reintroduce
+  `pull_request_target` or the fork-safety apparatus** — that would silently
+  revert this decision. A template re-sync should treat `pr.yaml` as diverged.
+- **If this repo ever accepts fork PRs**, revisit this: the canonical
+  `pull_request_target` + fork-safety model is the correct choice there, and this
+  ADR would be superseded.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+This directory records the significant, non-obvious decisions behind this
+template pack — the "why" that isn't visible in the code itself. Each ADR is a
+short, immutable record: once a decision is made it stays here; if it changes
+later, a **new** ADR supersedes the old one (which is marked *Superseded* rather
+than deleted, so the history stays intact).
+
+Format: [Michael Nygard's ADR style](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html)
+— Status, Context, Decision, Consequences.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-release-scoped-treatwarningsaserrors.md) | Release-scoped TreatWarningsAsErrors in generated projects | Accepted |
+| [0002](0002-automatic-command-registration.md) | Automatic command registration via an IConvention | Accepted |
+| [0003](0003-item-template-namespace-auto-detection.md) | Item-template namespace auto-detection with a coalesce fallback | Accepted |
+| [0004](0004-template-pack-ci-adaptations.md) | Template-pack CI/release adaptations | Accepted |
+
+## Adding an ADR
+
+Copy the format of an existing record, take the next number, and add a row to
+the index. Keep it short — an ADR is a paragraph of context and a paragraph of
+decision, not a design doc.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ Format: [Michael Nygard's ADR style](https://cognitect.com/blog/2011/11/15/docum
 | [0002](0002-automatic-command-registration.md) | Automatic command registration via an IConvention | Accepted |
 | [0003](0003-item-template-namespace-auto-detection.md) | Item-template namespace auto-detection with a coalesce fallback | Accepted |
 | [0004](0004-template-pack-ci-adaptations.md) | Template-pack CI/release adaptations | Accepted |
+| [0005](0005-pr-trigger-pull-request.md) | `pr.yaml` diverges from canonical: `pull_request`, no fork-safety apparatus | Accepted |
 
 ## Adding an ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ Format: [Michael Nygard's ADR style](https://cognitect.com/blog/2011/11/15/docum
 
 ## Adding an ADR
 
-Copy the format of an existing record, take the next number, and add a row to
-the index. Keep it short — an ADR is a paragraph of context and a paragraph of
+Copy [`TEMPLATE.md`](TEMPLATE.md), name it `NNNN-short-title.md` with the next
+number, fill in Status/Context/Decision/Consequences, and add a row to the index
+above. Keep it short — an ADR is a paragraph of context and a paragraph of
 decision, not a design doc.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# NNNN — <short title of the decision>
+
+- **Status:** Proposed | Accepted | Superseded by [NNNN](nnnn-....md)
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What is the situation that forces a decision? The constraints, the problem, the
+forces in tension. Just enough that a future reader understands *why* a choice was
+needed — no design doc, a paragraph or two.
+
+## Decision
+
+What we decided to do, stated plainly. If there are several parts, a short
+numbered list is fine.
+
+## Consequences
+
+What becomes true as a result — the good, the bad, and the follow-ups. Note
+anything a future change (or a template re-sync) must preserve or revisit.


### PR DESCRIPTION
## Summary
Adds `docs/adr/` (Michael Nygard format) with an index and four ADRs that record the non-obvious decisions behind this template pack — the "why" that isn't visible in the code:

- **0001** — Release-scoped `TreatWarningsAsErrors` in generated projects, and the `NoWarn` set (scaffolding TODOs + SDK-analyzer-drift false-positives).
- **0002** — Automatic command registration via `AutoRegisterCommandsConvention` (why auto-register vs. explicit `[Subcommand]`).
- **0003** — Item-template namespace auto-detection: the `msbuild:RootNamespace` bind + coalesce fallback, and the restore-first requirement.
- **0004** — Template-pack CI/release adaptations (under-src solution, no-tests tolerance, conditional docs, the generated-project smoke matrix).

These capture decisions made across this release cycle so the reasoning survives past the PR threads. Immutable-record convention documented in the ADR README (supersede, don't rewrite).

Docs-only. Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)