### PR TITLE
ci: SHA-pin all actions + zizmor workflow security audit (#221)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       has-docfx: ${{ steps.detect-docfx.outputs.has-docfx }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -101,7 +101,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -370,7 +370,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-coverage
           path: CoverageReport/
@@ -384,12 +384,12 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -410,6 +410,11 @@ jobs:
       - name: Pack NuGet packages
         id: check-packages
         shell: pwsh
+        env:
+          # Pass the tag through an env var rather than inlining ${{ }} in the
+          # script - avoids template-injection (a release tag name is
+          # attacker-influenceable input). Matches validate-release above.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           # Create output directory for NuGet packages
           $packagesPath = Join-Path $PWD 'nuget-packages'
@@ -438,7 +443,7 @@ jobs:
           # <PackageVersion> is baked into the .csproj. Tags conventionally
           # carry a leading 'v' (e.g. v0.6.0) — strip it before passing to
           # `dotnet pack /p:PackageVersion=...`.
-          $rawTag = '${{ github.event.release.tag_name }}'
+          $rawTag = $env:RELEASE_TAG_NAME
           $packageVersion = $rawTag -replace '^v', ''
           Write-Host "Using PackageVersion=$packageVersion (from tag $rawTag)" -ForegroundColor Cyan
 
@@ -591,7 +596,7 @@ jobs:
 
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
           path: ./nuget-packages/
@@ -610,7 +615,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -627,7 +632,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           # Install the same SDK set as validate-release so dotnet build can
           # compile every TFM the solution targets (some test projects span
@@ -705,7 +710,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -717,7 +722,7 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./packages
@@ -790,7 +795,7 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
@@ -802,7 +807,7 @@ jobs:
         # zip step below only runs when the download actually produced files.
         id: download-coverage
         continue-on-error: true
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -24,7 +24,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Detect stryker-config.json
         id: check
@@ -51,7 +53,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -80,7 +82,7 @@ jobs:
 
       - name: Upload Stryker report
         if: always() && steps.check.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stryker-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,9 +1,13 @@
-name: Workflow Security Audit (zizmor)
+name: Workflow Security Audit (zizmor + actionlint)
 
-# Static security audit of the GitHub Actions workflows themselves (issue #221).
-# zizmor catches the Actions-specific footguns the other scanners don't:
-# unpinned actions, template injection, credential persistence, dangerous
-# triggers. Runs on workflow changes, on push to main, and weekly.
+# Static audit of the GitHub Actions workflows themselves (issue #221).
+# - zizmor catches Actions-specific SECURITY footguns the other scanners don't:
+#   unpinned actions, template injection, credential persistence, dangerous triggers.
+# - actionlint catches CORRECTNESS bugs: workflow syntax, expression typos, bad
+#   glob/cron, and (via shellcheck, preinstalled on the runner) shell issues in
+#   run: steps.
+# Both tool versions are pinned so the gate stays reproducible. Runs on workflow
+# changes, on push to main, and weekly.
 
 on:
   pull_request:
@@ -41,4 +45,23 @@ jobs:
           # log but don't gate. Tighten --min-severity later if the noise floor
           # allows. Intentional accepted findings are annotated inline with
           # `# zizmor: ignore[<audit>]` in the workflow they apply to.
-          pipx run zizmor --min-severity=high .github/workflows/
+          # Version pinned so a new zizmor release can't change the gate under us.
+          pipx run zizmor==1.26.1 --min-severity=high .github/workflows/
+
+  actionlint:
+    name: "actionlint (Actions linter)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        run: |
+          # Pinned binary (reproducible); shellcheck is preinstalled on the runner
+          # so actionlint's shell-script checks run too.
+          curl -sSfL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
+            | tar xz actionlint
+          ./actionlint -color

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,44 @@
+name: Workflow Security Audit (zizmor)
+
+# Static security audit of the GitHub Actions workflows themselves (issue #221).
+# zizmor catches the Actions-specific footguns the other scanners don't:
+# unpinned actions, template injection, credential persistence, dangerous
+# triggers. Runs on workflow changes, on push to main, and weekly.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '30 5 * * 1'  # weekly Monday 05:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: "zizmor (Actions security audit)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        env:
+          # zizmor uses the token for its online checks (e.g. verifying an
+          # action ref is a real tag). Read-only; the workflow grants no more.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fail on high-severity findings; lower-severity notes surface in the
+          # log but don't gate. Tighten --min-severity later if the noise floor
+          # allows. Intentional accepted findings are annotated inline with
+          # `# zizmor: ignore[<audit>]` in the workflow they apply to.
+          pipx run zizmor --min-severity=high .github/workflows/


### PR DESCRIPTION
## Summary
Ran `zizmor` over the workflows and hardened what it flagged — **36 findings (28 high) → 0 high** after this change:

- **SHA-pin every action** to a commit hash with a `# vX` version comment (`actions/checkout@v7`, `actions/setup-dotnet@v5`, `actions/upload-artifact@v7`, `actions/download-artifact@v8.0.1`) across pr / release / docfx / stryker. Brings the repo into line with the fleet SHA-pin policy and closes the moved-tag supply-chain vector; the github-actions Dependabot ecosystem keeps them current. (`softprops/action-gh-release` was already pinned.)
- **template-injection fix** (release.yaml Pack step): pass the release tag via an `env:` var instead of inlining `${{ github.event.release.tag_name }}` in the PowerShell script — matches how `validate-release` already handles it.
- **artipacked fix** (stryker.yaml): add `persist-credentials: false` to the checkout.
- **dangerous-triggers**: annotated the intentional, documented `pull_request_target` with a justified `# zizmor: ignore[dangerous-triggers]` (removing it would break the trusted-config security model — see docs/WORKFLOW_SECURITY.md).

Adds **`.github/workflows/workflow-security.yml`** — runs zizmor on workflow changes, push to main, and weekly; **fails on high-severity findings** (lower ones surface but don't gate). Verified locally: the gate exits 0.

The one remaining finding is informational (`superfluous-actions`: zizmor suggests `gh release` in a script instead of the `softprops/action-gh-release` action) — left as-is; the action is well-established and now SHA-pinned, and rewriting it would be churn for no security gain.

## Note
This touches `pr.yaml`, so it will conflict with #270 (InspectCode, also edits pr.yaml). Whichever merges second needs a trivial rebase — I'll re-pin #270's added actions so it stays consistent with this policy.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
