### PR TITLE
ci: add OSSF Scorecard workflow (#220)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository != 'Chris-Wolfgang/repo-template'
     permissions:
+      # A job-level permissions block REPLACES the workflow-level read-all, so
+      # every scope the job needs must be listed here explicitly.
+      contents: read           # Scorecard + checkout read the repo
+      actions: read            # Scorecard reads workflow files (Token-Permissions / Dangerous-Workflow checks)
       security-events: write   # upload the SARIF to Code Scanning
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: OSSF Scorecard
+
+# Automated security-posture scoring (issue #220). OpenSSF Scorecard grades the
+# repo against a checklist (branch protection, pinned dependencies, token
+# permissions, dangerous workflow patterns, ...) and uploads the results as SARIF
+# to GitHub Code Scanning (Security → Code scanning). It complements the point
+# tools already here: gitleaks (secrets), CodeQL/DevSkim/InspectCode (code),
+# zizmor (workflow security) — Scorecard scores the *posture*, not the code.
+
+on:
+  # Re-score when branch-protection / ruleset settings change.
+  branch_protection_rule:
+  schedule:
+    - cron: '20 5 * * 1'  # weekly Monday 05:20 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege at the top; the analysis job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: "Scorecard analysis"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    permissions:
+      security-events: write   # upload the SARIF to Code Scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          # publish_results: false keeps the score private (Code Scanning only).
+          # Set to true to publish to the public OpenSSF dashboard and enable the
+          # Scorecard badge — that also requires adding `id-token: write` to this
+          # job's permissions. Left off by default; flipping it on is a
+          # deliberate "make our security posture public" decision.
+          publish_results: false
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/README.md
+++ b/README.md
@@ -205,6 +205,30 @@ See [Instructions.md](src/ConsoleAppTemplate/Content/Instructions.md) for detail
 
 ---
 
+## Security posture
+
+This repo runs [OpenSSF Scorecard](https://scorecard.dev/) (weekly + on push to `main`)
+to grade its security posture — branch protection, pinned dependencies, token
+permissions, dangerous-workflow patterns, and more. Results upload as SARIF to
+**Security → Code scanning**, alongside the other scanners (gitleaks, CodeQL, DevSkim,
+InspectCode, and zizmor for workflow security).
+
+- **Target score floor:** **≥ 7.0 / 10.** Investigate and address any check that
+  drops the aggregate below that; the per-check breakdown is in Code Scanning.
+- **Public badge / dashboard:** off by default (the score stays private in Code
+  Scanning). To publish to the public OpenSSF dashboard and enable the badge below,
+  set `publish_results: true` in [`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml)
+  (and add `id-token: write` to that job) — a deliberate "make our posture public"
+  decision. Once enabled, add:
+
+  ```markdown
+  [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Chris-Wolfgang/console-app-template/badge)](https://scorecard.dev/viewer/?uri=github.com/Chris-Wolfgang/console-app-template)
+  ```
+
+See [SECURITY.md](SECURITY.md) for how to report a vulnerability.
+
+---
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, coding standards, and PR checklist.


### PR DESCRIPTION
## Summary
Adds `.github/workflows/scorecard.yml` — OpenSSF Scorecard grades the repo's security posture against a standard checklist (branch protection / ruleset, pinned dependencies, token permissions, dangerous workflow patterns, …) and uploads the results as SARIF to GitHub **Code Scanning** (Security → Code scanning alerts).

It complements the point tools already here — gitleaks (secrets), CodeQL/DevSkim/InspectCode (code), zizmor (workflow security) — by scoring the *posture* rather than the code.

- Triggers: weekly, on push to `main`, on `branch_protection_rule` changes, and `workflow_dispatch`.
- Actions are SHA-pinned (`ossf/scorecard-action@…v2.4.3`, checkout, codeql upload-sarif) to match the #221 policy — so it also passes the new zizmor gate.
- **`publish_results: false`** by default — the score stays private (Code Scanning only). Flipping it to `true` publishes to the public OpenSSF dashboard and enables the Scorecard badge (and needs `id-token: write`); that's a deliberate "make our posture public" decision left to you, documented inline.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
