### PR TITLE
ci: add SLSA build-provenance attestation to release (#206)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -380,6 +380,10 @@ jobs:
     name: Pack & Validate NuGet
     needs: validate-release
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write       # mint the OIDC token the attestation is signed with
+      attestations: write   # write the SLSA build-provenance attestation
     outputs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
@@ -594,6 +598,18 @@ jobs:
             }
           }
 
+
+      # SLSA build-provenance attestation (issue #206). Records a signed,
+      # verifiable statement that these exact .nupkg files were built by this
+      # workflow at this commit. Stored in GitHub's attestation store (not
+      # embedded in the package — that would be NuGet package signing, which
+      # needs a code-signing certificate and is tracked separately). Consumers
+      # verify with: gh attestation verify <pkg>.nupkg --repo ${{ github.repository }}
+      - name: Attest build provenance for NuGet packages
+        if: steps.check-packages.outputs.has-packages == 'true'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'nuget-packages/*.nupkg'
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -604,7 +604,9 @@ jobs:
       # workflow at this commit. Stored in GitHub's attestation store (not
       # embedded in the package — that would be NuGet package signing, which
       # needs a code-signing certificate and is tracked separately). Consumers
-      # verify with: gh attestation verify <pkg>.nupkg --repo ${{ github.repository }}
+      # verify with:
+      #   gh attestation verify <pkg>.nupkg --repo Chris-Wolfgang/console-app-template
+      # (literal owner/repo - a ${{ }} expression wouldn't expand when copied to a shell)
       - name: Attest build provenance for NuGet packages
         if: steps.check-packages.outputs.has-packages == 'true'
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2


### PR DESCRIPTION
## Summary
Adds an [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) step to the `pack-and-validate` job — it records a **signed, verifiable statement** that these exact `.nupkg` files were built by this workflow at this commit (SLSA build provenance).

- Grants the job the `id-token: write` + `attestations: write` permissions the attestation needs (job-scoped; top-level stays `contents: read`).
- Attests `nuget-packages/*.nupkg` after packing, guarded by `has-packages`.
- The attestation lives in **GitHub's attestation store** — verifiable with `gh attestation verify <pkg>.nupkg --repo Chris-Wolfgang/console-app-template`. It is **not** embedded in the package. Embedding = NuGet **package signing**, which needs a code-signing certificate and is tracked separately (owner action) — deliberately out of scope here.
- Complements the CycloneDX SBOM already produced in the same job → the release now has both an SBOM *and* provenance.

## ⚠️ Stacked PR
Based on **`ci/221-workflow-security-audit` (#273)**, not `main`, because both edit `release.yaml`. The diff here is **just the 16-line attestation addition**. After #273 merges to main, I'll retarget this to `main` (GitHub auto-retargets on base-merge) and rebase if needed.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
