### PR TITLE
feat: optional health-check subcommand (#119)

### DIFF
--- a/src/ConsoleAppTemplate/Content/.template.config/dotnetcli.host.json
+++ b/src/ConsoleAppTemplate/Content/.template.config/dotnetcli.host.json
@@ -1,6 +1,8 @@
 {
     "symbolInfo": {
-
-
+        "HealthCheck": {
+            "longName": "health-check",
+            "shortName": ""
+        }
     }
 }

--- a/src/ConsoleAppTemplate/Content/.template.config/template.json
+++ b/src/ConsoleAppTemplate/Content/.template.config/template.json
@@ -118,8 +118,26 @@
 				"format": "yyyy"
 			},
 			"replaces": "{copyright year}"
+		},
+
+		"HealthCheck": {
+			"type": "parameter",
+			"datatype": "bool",
+			"description": "Include a 'health' subcommand that validates runtime dependencies and configuration (with a --json flag for container health probes).",
+			"defaultValue": "false"
 		}
 	},
+
+	"sources": [
+		{
+			"modifiers": [
+				{
+					"condition": "(!HealthCheck)",
+					"exclude": [ "Command/HealthCommand.cs" ]
+				}
+			]
+		}
+	],
 
 	"primaryOutputs": [
 		{ 

--- a/src/ConsoleAppTemplate/Content/Command/HealthCommand.cs
+++ b/src/ConsoleAppTemplate/Content/Command/HealthCommand.cs
@@ -42,30 +42,46 @@ internal class HealthCommand
     {
         logger.LogInformation("Starting {Command}", GetType().Name);
 
-        var checks = new List<HealthCheckResult>
+        try
         {
-            CheckConfigurationLoaded(configuration),
-            await CheckLogDirectoryWritableAsync(configuration, cancellationToken)
+            var checks = new List<HealthCheckResult>
+            {
+                CheckConfigurationLoaded(configuration),
+                await CheckLogDirectoryWritableAsync(configuration, cancellationToken)
 
-            // TODO Add your own checks here - e.g. database connectivity, downstream
-            // API reachability, or required files/directories. Return a HealthCheckResult
-            // from each so it appears in both the text and --json output below.
-        };
+                // TODO Add your own checks here - e.g. database connectivity, downstream
+                // API reachability, or required files/directories. Return a HealthCheckResult
+                // from each so it appears in both the text and --json output below.
+            };
 
-        var healthy = checks.TrueForAll(c => c.Passed);
+            cancellationToken.ThrowIfCancellationRequested();
 
-        if (Json)
-        {
-            WriteJson(console, checks, healthy);
+            var healthy = checks.TrueForAll(c => c.Passed);
+
+            if (Json)
+            {
+                WriteJson(console, checks, healthy);
+            }
+            else
+            {
+                WriteText(console, checks);
+            }
+
+            logger.LogInformation("Completed {Command} - {Status}", GetType().Name, healthy ? "healthy" : "unhealthy");
+
+            return healthy ? ExitCode.Success : ExitCode.ApplicationError;
         }
-        else
+        catch (OperationCanceledException e)
         {
-            WriteText(console, checks);
+            logger.LogWarning(e, "{Command} was canceled", GetType().Name);
+            return ExitCode.Canceled;
         }
-
-        logger.LogInformation("Completed {Command} - {Status}", GetType().Name, healthy ? "healthy" : "unhealthy");
-
-        return healthy ? ExitCode.Success : ExitCode.ApplicationError;
+        catch (Exception e)
+        {
+            logger.LogCritical(e, "Unhandled error: {Message}", e.Message);
+            await console.Error.WriteLineAsync(e.Message);
+            return ExitCode.ApplicationError;
+        }
     }
 
 
@@ -77,12 +93,9 @@ internal class HealthCommand
     {
         var loaded = configuration.GetChildren().Any();
 
-        return new HealthCheckResult
-        (
-            "configuration",
-            loaded,
-            loaded ? "Configuration loaded" : "No configuration sections found"
-        );
+        return loaded
+            ? HealthCheckResult.Pass("configuration", "Configuration loaded")
+            : HealthCheckResult.Fail("configuration", "No configuration sections found");
     }
 
 
@@ -97,21 +110,25 @@ internal class HealthCommand
         CancellationToken cancellationToken
     )
     {
-        var logDirectory = ResolveLogDirectory(configuration);
+        // The resolve is inside the try because a malformed configured path can make
+        // Path.GetDirectoryName throw (ArgumentException / PathTooLongException).
+        var logDirectory = "logs";
 
         try
         {
+            logDirectory = ResolveLogDirectory(configuration);
+
             Directory.CreateDirectory(logDirectory);
 
             var probe = Path.Combine(logDirectory, $".health-probe-{Guid.NewGuid():N}.tmp");
             await File.WriteAllTextAsync(probe, string.Empty, cancellationToken);
             File.Delete(probe);
 
-            return new HealthCheckResult("log-directory", true, $"Log directory writable ({logDirectory})");
+            return HealthCheckResult.Pass("log-directory", $"Log directory writable ({logDirectory})");
         }
-        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
-            return new HealthCheckResult("log-directory", false, $"Log directory not writable ({logDirectory}): {e.Message}");
+            return HealthCheckResult.Fail("log-directory", $"Log directory not writable ({logDirectory}): {e.Message}");
         }
     }
 
@@ -166,5 +183,12 @@ internal class HealthCommand
 
 
 
-    private sealed record HealthCheckResult(string Name, bool Passed, string Detail);
+    private sealed record HealthCheckResult(string Name, bool Passed, string Detail)
+    {
+        public static HealthCheckResult Pass(string name, string detail) => new(name, Passed: true, detail);
+
+
+
+        public static HealthCheckResult Fail(string name, string detail) => new(name, Passed: false, detail);
+    }
 }

--- a/src/ConsoleAppTemplate/Content/Command/HealthCommand.cs
+++ b/src/ConsoleAppTemplate/Content/Command/HealthCommand.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ConsoleAppTemplate.Command;
+
+/// <summary>
+/// Validates that the application's runtime dependencies and configuration are in a
+/// working state. Runs a set of lightweight checks and reports each result, exiting
+/// non-zero if any check fails.
+/// </summary>
+/// <remarks>
+/// Auto-registered as the <c>health</c> subcommand (see
+/// <see cref="Framework.AutoRegisterCommandsConvention"/>). Handy for fast production
+/// triage ("config issue or code issue?") and as a container health probe, e.g.
+/// <c>HEALTHCHECK CMD myapp health</c>. Use <c>--json</c> for machine-readable output.
+/// </remarks>
+[Command
+(
+    Description = "Validate runtime dependencies and configuration (config loaded, log directory writable).",
+    ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated
+)]
+internal class HealthCommand
+{
+    [Option
+        (
+            Description = "Emit machine-readable JSON instead of text - useful for container/orchestrator health probes."
+        )
+    ]
+    public bool Json { get; set; }
+
+
+
+    internal async Task<int> OnExecuteAsync
+    (
+        IConsole console,
+        IConfiguration configuration,
+        ILogger<HealthCommand> logger,
+        CancellationToken cancellationToken
+    )
+    {
+        logger.LogInformation("Starting {Command}", GetType().Name);
+
+        var checks = new List<HealthCheckResult>
+        {
+            CheckConfigurationLoaded(configuration),
+            await CheckLogDirectoryWritableAsync(configuration, cancellationToken)
+
+            // TODO Add your own checks here - e.g. database connectivity, downstream
+            // API reachability, or required files/directories. Return a HealthCheckResult
+            // from each so it appears in both the text and --json output below.
+        };
+
+        var healthy = checks.TrueForAll(c => c.Passed);
+
+        if (Json)
+        {
+            WriteJson(console, checks, healthy);
+        }
+        else
+        {
+            WriteText(console, checks);
+        }
+
+        logger.LogInformation("Completed {Command} - {Status}", GetType().Name, healthy ? "healthy" : "unhealthy");
+
+        return healthy ? ExitCode.Success : ExitCode.ApplicationError;
+    }
+
+
+
+    /// <summary>
+    /// Confirms configuration was loaded - i.e. at least one configuration section is present.
+    /// </summary>
+    private static HealthCheckResult CheckConfigurationLoaded(IConfiguration configuration)
+    {
+        var loaded = configuration.GetChildren().Any();
+
+        return new HealthCheckResult
+        (
+            "configuration",
+            loaded,
+            loaded ? "Configuration loaded" : "No configuration sections found"
+        );
+    }
+
+
+
+    /// <summary>
+    /// Confirms the log directory (from the Serilog file sink, defaulting to <c>logs/</c>)
+    /// exists and is writable by creating and deleting a probe file.
+    /// </summary>
+    private static async Task<HealthCheckResult> CheckLogDirectoryWritableAsync
+    (
+        IConfiguration configuration,
+        CancellationToken cancellationToken
+    )
+    {
+        var logDirectory = ResolveLogDirectory(configuration);
+
+        try
+        {
+            Directory.CreateDirectory(logDirectory);
+
+            var probe = Path.Combine(logDirectory, $".health-probe-{Guid.NewGuid():N}.tmp");
+            await File.WriteAllTextAsync(probe, string.Empty, cancellationToken);
+            File.Delete(probe);
+
+            return new HealthCheckResult("log-directory", true, $"Log directory writable ({logDirectory})");
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return new HealthCheckResult("log-directory", false, $"Log directory not writable ({logDirectory}): {e.Message}");
+        }
+    }
+
+
+
+    /// <summary>
+    /// Reads the directory of the first Serilog file sink's <c>path</c> from configuration,
+    /// falling back to <c>logs</c> when no file sink path is configured.
+    /// </summary>
+    private static string ResolveLogDirectory(IConfiguration configuration)
+    {
+        foreach (var sink in configuration.GetSection("Serilog:WriteTo").GetChildren())
+        {
+            var path = sink["Args:path"];
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                var directory = Path.GetDirectoryName(path);
+                return string.IsNullOrWhiteSpace(directory) ? "." : directory;
+            }
+        }
+
+        return "logs";
+    }
+
+
+
+    private static void WriteText(IConsole console, IReadOnlyList<HealthCheckResult> checks)
+    {
+        foreach (var check in checks)
+        {
+            console.WriteLine($"{(check.Passed ? "✅" : "❌")} {check.Detail}");
+        }
+    }
+
+
+
+    private static void WriteJson(IConsole console, IReadOnlyList<HealthCheckResult> checks, bool healthy)
+    {
+        var payload = new
+        {
+            status = healthy ? "healthy" : "unhealthy",
+            checks = checks.Select(c => new
+            {
+                name = c.Name,
+                status = c.Passed ? "pass" : "fail",
+                detail = c.Detail
+            })
+        };
+
+        console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+
+
+    private sealed record HealthCheckResult(string Name, bool Passed, string Detail);
+}


### PR DESCRIPTION
## Summary
Adds an **opt-in `health` subcommand** to the console template, controlled by a new `--health-check` template parameter (default `false`).

- **Off (default):** no health files generated — zero added complexity for users who don't want it.
- **On (`--health-check`):** `Command/HealthCommand.cs` is included. It runs lightweight checks (**configuration loaded**, **log directory writable** — the log dir is read from the Serilog file sink, defaulting to `logs/`) and exits non-zero if any fail.
- **`--json` flag** emits machine-readable output for container/orchestrator probes (`HEALTHCHECK CMD myapp health`).
- A `TODO` extension point shows users where to add their own checks (DB, downstream APIs, files).

## Wiring
- `template.json`: `HealthCheck` bool symbol + a `sources` modifier that excludes `Command/HealthCommand.cs` when `(!HealthCheck)`.
- `dotnetcli.host.json`: maps the symbol to the `--health-check` CLI flag (symbol kept hyphen-free so the exclude condition parses).
- **No `Program.cs` change** — `AutoRegisterCommandsConvention` (from #1) discovers the `[Command]` class and registers `health` automatically.

## Verified locally (pack → install → generate both ways → build → run)
```
default:        HealthCommand.cs EXCLUDED, Release/net8 build clean (0 warnings)
--health-check: HealthCommand.cs included, Release/net8 build clean, and:

$ myapp health
✅ Configuration loaded
✅ Log directory writable (logs)     (exit 0)

$ myapp health --json
{ "status": "healthy", "checks": [ {"name":"configuration","status":"pass",...}, ... ] }
```

## Follow-up (not in this PR)
The generated `HealthCommand.cs` only compiles under CI when the smoke matrix generates *with* `--health-check`. Adding a `--health-check` leg to the `template-smoke-matrix` would guard it against future SDK-analyzer drift — deferred here because it edits `pr.yaml` (which #270/#273 already contend over).

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
