### PR TITLE
ci: fit pr.yaml to this repo (pull_request, drop fork-safety apparatus)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,12 +2,12 @@
 # Builds all template projects and runs security scanning
 # No test stage — this repo contains only dotnet new templates
 #
-# SECURITY NOTE:
-# - Uses pull_request_target to run workflow from the trusted main branch
-# - This prevents malicious workflow YAML changes in untrusted PR branches from taking effect
-# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code
-# - Configuration files (.editorconfig, etc.) are fetched from main to prevent bypasses
-# - persist-credentials: false prevents the checkout token from being written to git config
+# This repo's PRs come from same-repo branches (single maintainer), not
+# untrusted forks, so it uses `pull_request` (not `pull_request_target`).
+# That runs the PR's own workflow against the PR's own code - simpler, and
+# it drops the fork-safety apparatus (main-ref checkouts, fetch-config-from-main,
+# the protected-file guard) that only makes sense for untrusted fork PRs.
+# persist-credentials: false still avoids writing the token into git config.
 
 name: PR Checks
 
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -33,9 +33,8 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
           fetch-depth: 0
 
@@ -58,99 +57,9 @@ jobs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-          git fetch origin main:main-branch
-
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-          )
-
-          for config_file in "${config_files[@]}"; do
-            if [[ "$config_file" == *"*"* ]]; then
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Detect protected configuration file changes
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Checking for changes to protected configuration files in this PR..."
-
-          if ! git cat-file -e main-branch 2>/dev/null; then
-            echo "❌ main-branch ref not found - cannot detect configuration file changes"
-            exit 1
-          fi
-
-          changed_files=()
-
-          exact_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-          )
-
-          for config_file in "${exact_files[@]}"; do
-            if ! git diff --quiet main-branch HEAD -- "$config_file" 2>/dev/null; then
-              changed_files+=("$config_file")
-            fi
-          done
-
-          while IFS= read -r file; do
-            changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '\.(globalconfig|ruleset)$' || true)
-
-          if [ ${#changed_files[@]} -gt 0 ]; then
-            echo ""
-            echo "⚠️  PROTECTED CONFIGURATION FILES CHANGED IN THIS PR:"
-            for file in "${changed_files[@]}"; do
-              echo "  - $file"
-            done
-            echo ""
-            echo "❌ CI uses the main branch version of these files to prevent security bypasses."
-            echo "   The PR's changes to these files were NOT tested by CI."
-            echo "   A maintainer must manually review and verify these changes before merging."
-            exit 1
-          else
-            echo "✅ No protected configuration files changed - CI fully validates this PR"
-          fi
 
       - name: Check for .NET project files
         id: check-projects
@@ -173,51 +82,12 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-          git fetch origin main:main-branch
-
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          foreach ($configFile in $configFiles) {
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              # Out-File -NoNewline concatenates ALL pipeline lines into one giant
-              # line, silently corrupting the fetched file (an unparseable
-              # .editorconfig makes every analyzer fall back to default severity).
-              # Set-Content writes the lines joined with proper newlines.
-              git show "main-branch:$configFile" | Set-Content -Path $configFile -Encoding utf8NoBOM
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-          # Reset exit code — git cat-file -e leaves $LASTEXITCODE=1 for missing files
-          exit 0
-
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -319,15 +189,14 @@ jobs:
             sdk: "10.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
       - name: Setup .NET
         # The matrix SDK builds the generated project; 10.0.x packs the
         # template itself (the pack csproj targets netstandard2.0).
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             ${{ matrix.sdk }}.x
@@ -425,13 +294,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -461,7 +329,7 @@ jobs:
             --no-build
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
         with:
           sarif_file: inspect.sarif
 
@@ -487,13 +355,12 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -512,7 +379,7 @@ jobs:
 
       - name: Upload DevSkim Results as Artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: devskim-results
           path: devskim-results.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       has-docfx: ${{ steps.detect-docfx.outputs.has-docfx }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -101,7 +101,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -370,7 +370,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-coverage
           path: CoverageReport/
@@ -384,12 +384,12 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -410,6 +410,11 @@ jobs:
       - name: Pack NuGet packages
         id: check-packages
         shell: pwsh
+        env:
+          # Pass the tag through an env var rather than inlining ${{ }} in the
+          # script - avoids template-injection (a release tag name is
+          # attacker-influenceable input). Matches validate-release above.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           # Create output directory for NuGet packages
           $packagesPath = Join-Path $PWD 'nuget-packages'
@@ -438,7 +443,7 @@ jobs:
           # <PackageVersion> is baked into the .csproj. Tags conventionally
           # carry a leading 'v' (e.g. v0.6.0) — strip it before passing to
           # `dotnet pack /p:PackageVersion=...`.
-          $rawTag = '${{ github.event.release.tag_name }}'
+          $rawTag = $env:RELEASE_TAG_NAME
           $packageVersion = $rawTag -replace '^v', ''
           Write-Host "Using PackageVersion=$packageVersion (from tag $rawTag)" -ForegroundColor Cyan
 
@@ -591,7 +596,7 @@ jobs:
 
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
           path: ./nuget-packages/
@@ -610,7 +615,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -627,7 +632,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           # Install the same SDK set as validate-release so dotnet build can
           # compile every TFM the solution targets (some test projects span
@@ -705,7 +710,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -717,7 +722,7 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./packages
@@ -790,7 +795,7 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
@@ -802,7 +807,7 @@ jobs:
         # zip step below only runs when the download actually produced files.
         id: download-coverage
         continue-on-error: true
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -380,6 +380,10 @@ jobs:
     name: Pack & Validate NuGet
     needs: validate-release
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write       # mint the OIDC token the attestation is signed with
+      attestations: write   # write the SLSA build-provenance attestation
     outputs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
@@ -594,6 +598,18 @@ jobs:
             }
           }
 
+
+      # SLSA build-provenance attestation (issue #206). Records a signed,
+      # verifiable statement that these exact .nupkg files were built by this
+      # workflow at this commit. Stored in GitHub's attestation store (not
+      # embedded in the package — that would be NuGet package signing, which
+      # needs a code-signing certificate and is tracked separately). Consumers
+      # verify with: gh attestation verify <pkg>.nupkg --repo ${{ github.repository }}
+      - name: Attest build provenance for NuGet packages
+        if: steps.check-packages.outputs.has-packages == 'true'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'nuget-packages/*.nupkg'
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -604,7 +604,9 @@ jobs:
       # workflow at this commit. Stored in GitHub's attestation store (not
       # embedded in the package — that would be NuGet package signing, which
       # needs a code-signing certificate and is tracked separately). Consumers
-      # verify with: gh attestation verify <pkg>.nupkg --repo ${{ github.repository }}
+      # verify with:
+      #   gh attestation verify <pkg>.nupkg --repo Chris-Wolfgang/console-app-template
+      # (literal owner/repo - a ${{ }} expression wouldn't expand when copied to a shell)
       - name: Attest build provenance for NuGet packages
         if: steps.check-packages.outputs.has-packages == 'true'
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -24,7 +24,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Detect stryker-config.json
         id: check
@@ -51,7 +53,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -80,7 +82,7 @@ jobs:
 
       - name: Upload Stryker report
         if: always() && steps.check.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stryker-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,9 +1,13 @@
-name: Workflow Security Audit (zizmor)
+name: Workflow Security Audit (zizmor + actionlint)
 
-# Static security audit of the GitHub Actions workflows themselves (issue #221).
-# zizmor catches the Actions-specific footguns the other scanners don't:
-# unpinned actions, template injection, credential persistence, dangerous
-# triggers. Runs on workflow changes, on push to main, and weekly.
+# Static audit of the GitHub Actions workflows themselves (issue #221).
+# - zizmor catches Actions-specific SECURITY footguns the other scanners don't:
+#   unpinned actions, template injection, credential persistence, dangerous triggers.
+# - actionlint catches CORRECTNESS bugs: workflow syntax, expression typos, bad
+#   glob/cron, and (via shellcheck, preinstalled on the runner) shell issues in
+#   run: steps.
+# Both tool versions are pinned so the gate stays reproducible. Runs on workflow
+# changes, on push to main, and weekly.
 
 on:
   pull_request:
@@ -41,4 +45,23 @@ jobs:
           # log but don't gate. Tighten --min-severity later if the noise floor
           # allows. Intentional accepted findings are annotated inline with
           # `# zizmor: ignore[<audit>]` in the workflow they apply to.
-          pipx run zizmor --min-severity=high .github/workflows/
+          # Version pinned so a new zizmor release can't change the gate under us.
+          pipx run zizmor==1.26.1 --min-severity=high .github/workflows/
+
+  actionlint:
+    name: "actionlint (Actions linter)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        run: |
+          # Pinned binary (reproducible); shellcheck is preinstalled on the runner
+          # so actionlint's shell-script checks run too.
+          curl -sSfL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
+            | tar xz actionlint
+          ./actionlint -color

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,44 @@
+name: Workflow Security Audit (zizmor)
+
+# Static security audit of the GitHub Actions workflows themselves (issue #221).
+# zizmor catches the Actions-specific footguns the other scanners don't:
+# unpinned actions, template injection, credential persistence, dangerous
+# triggers. Runs on workflow changes, on push to main, and weekly.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '30 5 * * 1'  # weekly Monday 05:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: "zizmor (Actions security audit)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        env:
+          # zizmor uses the token for its online checks (e.g. verifying an
+          # action ref is a real tag). Read-only; the workflow grants no more.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fail on high-severity findings; lower-severity notes surface in the
+          # log but don't gate. Tighten --min-severity later if the noise floor
+          # allows. Intentional accepted findings are annotated inline with
+          # `# zizmor: ignore[<audit>]` in the workflow they apply to.
+          pipx run zizmor --min-severity=high .github/workflows/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A robust set of .NET templates for building console applications with modern dev
 
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Template.Console.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Template.Console)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Template.Console.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Template.Console)
-[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/console-app-template/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/console-app-template/actions/workflows/pr.yaml)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/console-app-template/pr.yaml?event=pull_request&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/console-app-template/actions/workflows/pr.yaml)
 [![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/console-app-template/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/console-app-template/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)


### PR DESCRIPTION
## Why
`pr.yaml` was a copy of the canonical **library-repo** workflow, whose entire security model exists for **untrusted fork PRs**. This repo's PRs come from same-repo branches (single maintainer), so that apparatus is pure complexity — and it's the direct cause of several recurring headaches this cycle:
- the `dangerous-triggers` zizmor suppression `pull_request_target` forced
- the protected-file-PR splits (the "Detect protected configuration file changes" guard)
- CI validating **main's** config instead of the **PR's**

## What changed
Switched `on: pull_request_target` → `on: pull_request`, and removed only the pieces that are fork-model-specific and would be *incorrect* under `pull_request`:
- the explicit `ref: refs/pull/<n>/head` on all 6 checkouts — the default ref under `pull_request` already checks out the PR
- the two **"Fetch trusted configuration files from main branch"** steps
- the **"Detect protected configuration file changes"** guard — its error literally says *"CI uses the main branch version to prevent bypasses,"* which is **false** under `pull_request` (CI now tests the PR's own config), so keeping it would make it lie

## What stayed (kept as close to canonical as possible)
- **All six jobs and their names** — so the branch ruleset's required checks still match
- The `.NET project` detection + `has-projects` gating, gitleaks, DevSkim, InspectCode, the smoke matrix
- SHA-pinned the actions in the rewritten checkout blocks while here
- Removing `pull_request_target` also drops the dangerous-trigger → **zizmor clean, no suppression needed**

Verified: YAML valid, all 6 jobs present, 0 `refs/pull`/`main-branch`/bare-`@vN` remnants, zizmor `--min-severity=high` reports no findings.

## Coordination
This **overlaps #273** (which also pins pr.yaml's actions + suppresses the pr.yaml dangerous-trigger). Once this lands, #273 should drop its pr.yaml changes (and the now-unnecessary `# zizmor: ignore[dangerous-triggers]`) and keep only release.yaml/docfx/stryker pins + the `workflow-security.yml` gate.

> Note: as a workflow-only PR, this will likely hit the known CodeQL-`neutral` ruleset block — that's the separate ruleset issue, not something this change introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
