### PR TITLE
docs: migration guide for breaking template changes (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** the `--response-file` template parameter's choice values were shortened —
+  `ParseArgsAsLineSeparated` → `LineSeparated`, `ParseArgsAsSpaceSeparated` → `SpaceSeparated`
+  (default is now `LineSeparated`). Scripts/CI that pin the old values must update. See the
+  [Migration Guide](docs/MIGRATION.md).
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## References & Further Reading
 
+- [CHANGELOG](CHANGELOG.md) · [Migration Guide](docs/MIGRATION.md) (breaking template changes)
 - [Serilog Documentation](https://serilog.net/)
 - [McMaster.Extensions.CommandLineUtils](https://github.com/natemcmaster/CommandLineUtils)
 - [Microsoft.Extensions.Hosting](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -31,9 +31,9 @@ generated code is identical; only the value you pass on the command line changed
 
 The default also changed from `ParseArgsAsLineSeparated` to `LineSeparated`.
 
-**Action:** if you scaffold from a script/CI that passes `--response-file
-ParseArgsAs…`, update the value. Interactive users who pick from the prompt are
-unaffected.
+**Action:** if you scaffold from a script/CI that passes
+`--response-file ParseArgsAs…`, update the value. Interactive users who pick from
+the prompt are unaffected.
 
 ---
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,45 @@
+# Migration Guide
+
+How to update when a new version of the Wolfgang console templates makes a
+**breaking change**. Because these are `dotnet new` templates, "breaking" means a
+change to the **template's CLI surface** (a parameter name or its accepted values)
+or to the **generated project's structure/conventions** — not a runtime API.
+
+Versions follow [SemVer](https://semver.org/). Breaking changes are always listed
+here and flagged **BREAKING** in the [CHANGELOG](../CHANGELOG.md); pre-1.0 they may
+land in a MINOR release.
+
+Already-generated projects are unaffected by template changes — migration only
+matters if you **re-scaffold** (especially from a script or CI that pins parameter
+values).
+
+---
+
+## Unreleased
+
+### `--response-file` choice values shortened
+
+Affects `cwconsole`, `cwsubcmd`, and `cwsubcmdetl`. The `--response-file`
+parameter's accepted values dropped the internal `ParseArgsAs…` prefix. The
+generated code is identical; only the value you pass on the command line changed.
+
+| Before | After |
+|--------|-------|
+| `--response-file ParseArgsAsLineSeparated` | `--response-file LineSeparated` |
+| `--response-file ParseArgsAsSpaceSeparated` | `--response-file SpaceSeparated` |
+| `--response-file Disabled` | `--response-file Disabled` *(unchanged)* |
+
+The default also changed from `ParseArgsAsLineSeparated` to `LineSeparated`.
+
+**Action:** if you scaffold from a script/CI that passes `--response-file
+ParseArgsAs…`, update the value. Interactive users who pick from the prompt are
+unaffected.
+
+---
+
+## Adding an entry
+
+When a change renames/retypes a template parameter, changes an accepted value, or
+alters the generated project's shape, add a section here (newest first) with a
+before/after table and a one-line **Action**, and mirror it in the CHANGELOG under
+a **BREAKING** note.


### PR DESCRIPTION
## Summary
Adds **`docs/MIGRATION.md`** — how to update when a template makes a **breaking change**. For a `dotnet new` template pack, "breaking" means a change to the template's CLI surface (a parameter or its accepted values) or to the generated project's shape — not a runtime API. Already-generated projects are unaffected; migration only matters when re-scaffolding from a script/CI.

First documented entry: the **`--response-file` choice-value rename** that shipped in #257 but was never written down —
- `ParseArgsAsLineSeparated` → `LineSeparated`
- `ParseArgsAsSpaceSeparated` → `SpaceSeparated`
- default `ParseArgsAsLineSeparated` → `LineSeparated`

Also:
- Records it as a **BREAKING** entry in the CHANGELOG `[Unreleased]` section (feeds the pending v0.6.0 CHANGELOG).
- Links CHANGELOG + Migration Guide from the README.

Base: `vNext`.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
