### PR TITLE
ci: publish via NuGet trusted publishing (OIDC), drop the API key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -721,11 +721,19 @@ jobs:
           Write-Host "Documentation built successfully - release may proceed"
 
   # Publish to NuGet (only if validation passed)
+  # Publish to NuGet via Trusted Publishing (OIDC) — no long-lived NUGET_API_KEY.
+  # Requires a Trusted Publishing policy on nuget.org for owner=Chris-Wolfgang,
+  # repo=console-app-template, workflow=release.yaml, for each package id.
+  # NuGet/login exchanges the workflow's OIDC token for a ~1-hour temporary key,
+  # so it MUST run immediately before the push (not at job start).
   publish-nuget:
     name: Publish to NuGet.org
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
@@ -745,22 +753,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        uses: NuGet/login@ebc737b6fc418a6ca0073cf116ec8dc156d8b81e # v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -17,19 +17,25 @@ The release workflow triggers when you **publish a GitHub Release** and implemen
 
 Complete the following one-time setup so that the workflow can publish releases:
 
-### Add NuGet API Key Secret
+### Configure Trusted Publishing (OIDC)
 
-**Location:** Settings → Secrets and variables → Actions → New repository secret
+Publishing uses **NuGet Trusted Publishing** — no long-lived `NUGET_API_KEY` secret.
+The workflow presents a GitHub OIDC token and `NuGet/login` exchanges it for a
+short-lived (~1 hour) key at push time.
 
-1. Click **"New repository secret"**
-2. **Name:** `NUGET_API_KEY`
-3. **Value:** Your NuGet.org API key
-   - Get your key from [NuGet.org Account → API Keys](https://www.nuget.org/account/apikeys)
-   - Recommended scopes: **Push new packages and package versions**
-   - Set expiration date (recommended: 1 year)
-4. Click **"Add secret"**
+**One-time setup on nuget.org** (Account → Trusted Publishing), one policy **per
+package id** (`Wolfgang.Template.Console`, `Wolfgang.Template.Console.Subcommand`,
+`Wolfgang.Template.Console.ETL-SubCommand`):
 
-**What this does:** Allows the workflow to authenticate with NuGet.org and publish packages. The workflow validates this secret exists before attempting to publish.
+1. **Repository owner:** `Chris-Wolfgang`
+2. **Repository:** `console-app-template`
+3. **Workflow file:** `release.yaml`
+4. (Optional) restrict to the environment/branch you release from.
+
+**What this does:** the `publish-nuget` job (with `permissions: id-token: write`)
+mints an OIDC token; `NuGet/login` trades it for a temporary key scoped to these
+packages from this repo. Nothing long-lived is stored, so there is no key to leak
+or rotate. (If you previously configured a `NUGET_API_KEY` secret, delete it.)
 
 ### Verify Branch Protection Rules
 
@@ -86,9 +92,9 @@ The workflow triggers automatically when the release is published.
    - ✅ Auto-passes if packages are valid
 
 3. **Job 3: publish-nuget** (1-2 minutes)
-   - Validates NUGET_API_KEY secret
+   - Logs in via OIDC trusted publishing (`NuGet/login` → temporary key)
    - Publishes packages to NuGet.org automatically
-   - ✅ Auto-completes if secret is valid
+   - ✅ Auto-completes if the trusted-publishing policy matches this repo/workflow
 
 ### Monitoring the Workflow
 
@@ -98,14 +104,16 @@ The workflow triggers automatically when the release is published.
 
 ## Troubleshooting
 
-### "NUGET_API_KEY secret not configured" Error
+### Trusted-publishing login fails (401 / no matching policy)
 
-**Problem:** The `publish-nuget` job fails with secret validation error.
+**Problem:** The `publish-nuget` job fails at `NuGet/login` or `dotnet nuget push`
+with an unauthorized / no-matching-trusted-publishing-policy error.
 
 **Solution:**
-1. Verify the secret name is exactly `NUGET_API_KEY` (case-sensitive)
-2. Re-add the secret in Settings → Secrets → Actions
-3. Re-run the workflow from the Actions tab (do not re-publish the release)
+1. Confirm a Trusted Publishing policy exists on nuget.org for **each** package id,
+   with owner `Chris-Wolfgang`, repo `console-app-template`, workflow `release.yaml`.
+2. Confirm the `publish-nuget` job has `permissions: id-token: write`.
+3. Re-run the workflow from the Actions tab (do not re-publish the release).
 
 ### Tests Fail on Specific Framework
 
@@ -192,7 +200,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 ┌─────────────────────────────────────────────────────────────┐
 │  Job 3: publish-nuget (Windows)                             │
 │  • Download packages                                        │
-│  • Validate NUGET_API_KEY                                   │
+│  • NuGet/login (OIDC → temporary key)                       │
 │  • Publish to NuGet.org automatically                       │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -32,7 +32,7 @@ template — that's their threat model (see the "consumer inherits" notes below)
 | **R**epudiation | "We didn't publish that version" | Releases are tag-driven and logged; provenance attestation ties each package to a workflow run + commit. |
 | **I**nfo disclosure | A secret committed into a template payload and shipped | **gitleaks** secret scan on every PR + secret scanning/push protection on the repo. |
 | **D**oS | n/a | Not a served asset; NuGet hosts the package. |
-| **E**levation | A compromised publish key ships a rogue version | Least-privilege NuGet key (scoped, push-only, expiring); **OIDC trusted publishing** is the recommended upgrade (no long-lived key); see [DISASTER-RECOVERY.md](DISASTER-RECOVERY.md). |
+| **E**levation | A compromised publish key ships a rogue version | Publishing uses **OIDC trusted publishing** (`NuGet/login`): no long-lived key exists — the workflow trades its OIDC token for a ~1-hour key scoped to publishing these package ids from this repo, so there is nothing to steal or rotate. |
 
 ### 2. Publish / CI pipeline
 
@@ -41,7 +41,7 @@ template — that's their threat model (see the "consumer inherits" notes below)
 | **S**poofing | A PR from a fork runs with write scope | PRs use `pull_request` with `contents: read` and no secret exposure to PR code (see [ADR 0005](adr/0005-pr-trigger-pull-request.md)). |
 | **T**ampering | A moved action tag pulls in malicious code; workflow-YAML injection | **All actions SHA-pinned**; **zizmor** + **actionlint** gate the workflows (template injection, unpinned uses, dangerous triggers); template tag values passed via `env:` not inline `${{ }}`. |
 | **R**epudiation | Unattributed changes to workflows/config | Branch ruleset on `main` (required checks, review, non-fast-forward, deletion protection); audit log. |
-| **I**nfo disclosure | `NUGET_API_KEY` leaked into logs/artifacts | `persist-credentials: false` on checkouts; secrets referenced only where needed; OIDC removes the long-lived key entirely. |
+| **I**nfo disclosure | A publish secret leaked into logs/artifacts | No long-lived publish secret exists — OIDC issues a ~1-hour token per run; `persist-credentials: false` on checkouts; least-privilege `GITHUB_TOKEN`. |
 | **D**oS | n/a | — |
 | **E**levation | An over-scoped `GITHUB_TOKEN` | Workflow-level `contents: read`; jobs opt into the minimum extra scope (e.g. `attestations: write`, `security-events: write`) only where required. |
 


### PR DESCRIPTION
## Summary
Migrates release publishing from a long-lived **`NUGET_API_KEY` secret** to **NuGet Trusted Publishing (OIDC)** — matching the fleet direction (piloted on ETL-SqlBulkCopy).

- `publish-nuget` now has `permissions: id-token: write` and a **SHA-pinned `NuGet/login@v1`** step that trades the workflow's OIDC token for a ~1-hour key, run immediately before `dotnet nuget push`.
- Removed the `Validate NUGET_API_KEY` step and every secret reference; the push uses `steps.nuget-login.outputs.NUGET_API_KEY` (the ephemeral key).

## Docs updated to match
- **RELEASE-WORKFLOW-SETUP.md** — "Configure Trusted Publishing" (a per-package nuget.org policy) instead of adding a secret; troubleshooting + architecture diagram updated.
- **THREAT-MODEL.md** — the two publish-key rows now say OIDC (no long-lived key to steal or rotate), and the `DISASTER-RECOVERY.md` link is dropped (that runbook was about API-key rotation, which no longer applies).

## ⚠️ Action required on your side (nuget.org)
Add a Trusted Publishing policy for **each** package id — `Wolfgang.Template.Console`, `Wolfgang.Template.Console.Subcommand`, `Wolfgang.Template.Console.ETL-SubCommand` — with owner `Chris-Wolfgang`, repo `console-app-template`, workflow `release.yaml`. After this merges + the policy exists, **delete the `NUGET_API_KEY` repo secret**.

Verified: `release.yaml` passes actionlint + zizmor (`NuGet/login` SHA-pinned); 0 secret references remain. Base: `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
