### PR TITLE
release: prepare v0.6.0 (CHANGELOG + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** the `--response-file` template parameter's choice values were shortened —
-  `ParseArgsAsLineSeparated` → `LineSeparated`, `ParseArgsAsSpaceSeparated` → `SpaceSeparated`
-  (default is now `LineSeparated`). Scripts/CI that pin the old values must update. See the
-  [Migration Guide](docs/MIGRATION.md).
-
 ### Deprecated
 
 ### Removed
@@ -23,3 +18,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.6.0] - 2026-07-12
+
+### Added
+
+- Optional **`health` subcommand** (opt-in via `--health-check`) that validates runtime
+  dependencies/configuration, with a `--json` flag for container health probes (#119).
+- **Architecture Decision Records** under `docs/adr/` (#218), and a **migration guide**
+  (`docs/MIGRATION.md`) for breaking template changes (#217).
+- **STRIDE threat model** (`docs/THREAT-MODEL.md`) tying each threat to its control (#210).
+- **Dependency license audit** — fails the build if the generated app's runtime graph pulls a
+  non-permissive license (#216).
+- **OSSF Scorecard** workflow uploading results to Code Scanning (#220).
+- **SLSA build-provenance attestation** on the published packages (#206).
+- **Workflow security audit** — a zizmor + actionlint gate over all workflows (#221) — and a
+  **ReSharper InspectCode** check in PR CI (#235).
+- **Reproducible-build verification** for the template packages (#214) and a **snapshot test**
+  of the generated project output (#208).
+
+### Changed
+
+- **BREAKING:** the `--response-file` template parameter's choice values were shortened —
+  `ParseArgsAsLineSeparated` → `LineSeparated`, `ParseArgsAsSpaceSeparated` → `SpaceSeparated`
+  (default is now `LineSeparated`). Scripts/CI that pin the old values must update. See the
+  [Migration Guide](docs/MIGRATION.md).
+- Publishing now uses **NuGet Trusted Publishing (OIDC)** instead of a long-lived
+  `NUGET_API_KEY` secret (#283).
+- `pr.yaml` now triggers on **`pull_request`** (was `pull_request_target`) and drops the
+  fork-safety apparatus that only applies to untrusted fork PRs (#278, [ADR 0005](docs/adr/0005-pr-trigger-pull-request.md)).
+- All GitHub Actions are **SHA-pinned** (#221).
+
+### Security
+
+- Supply-chain hardening across the board: SHA-pinned actions, CycloneDX SBOM + SLSA
+  attestation, permissive-only license audit, OSSF Scorecard, a zizmor/actionlint workflow
+  audit, and OIDC publishing (no long-lived key to leak or rotate).

--- a/src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj
+++ b/src/ConsoleAppTemplate/dotnet.consoleapp.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.6.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console</PackageId>
     <Title>Wolfgang Console App</Title>
     <Authors>Chris Wolfgang</Authors>

--- a/src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj
+++ b/src/EtlSubCommandTemplate/dotnet.etl-subcommand.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.6.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console.ETL-SubCommand</PackageId>
     <Title>Wolfgang Console ETL Subcommand</Title>
     <Authors>Chris Wolfgang</Authors>

--- a/src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj
+++ b/src/SubCommandTemplate/dotnet.subcommand.template.pack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.6.0</PackageVersion>
     <PackageId>Wolfgang.Template.Console.Subcommand</PackageId>
     <Title>Wolfgang Console Subcommand</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
## Summary
Release prep for **v0.6.0** (MINOR — new features plus a pre-1.0 breaking change):

- **CHANGELOG** — adds the `[0.6.0]` section documenting the whole cycle: the health subcommand (#119); ADRs (#218), migration guide (#217), threat model (#210); license audit (#216), OSSF Scorecard (#220), SLSA attestation (#206), zizmor+actionlint audit (#221), InspectCode (#235), reproducible-build (#214) and snapshot (#208) checks; the `pull_request` pr.yaml switch (#278); OIDC publishing (#283); SHA-pinning; and the response-file **BREAKING** change (#257).
- **Version bump** — the three template packs `0.5.0 → 0.6.0`. The generated-app template default stays `0.1.0`.

## Release sequence (after this + #283 land in vNext)
1. Merge **vNext → main** (the gated release merge).
2. Ensure the nuget.org **Trusted Publishing** policies exist (per #283).
3. **You create the `v0.6.0` release/tag** on `main` → `release.yaml` publishes all three packages via OIDC.

Base: `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
