### PR TITLE
ci: add an ARM64 (Linux) smoke-matrix leg (#286)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -183,6 +183,11 @@ jobs:
             sdk: "8.0"
           - os: macos-latest
             sdk: "8.0"
+          # ARM64 Linux (free runner for public repos). The generated app is pure
+          # managed .NET, so this is a low-signal but near-zero-cost proof that it
+          # packs/installs/builds/runs on ARM64 too.
+          - os: ubuntu-24.04-arm
+            sdk: "8.0"
           - os: ubuntu-latest
             sdk: "9.0"
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds one **`ubuntu-24.04-arm` / SDK 8.0** leg to the `template-smoke-matrix` in `pr.yaml` — the free ARM64 Linux runner for public repos. It runs the full generated-app smoke (pack → install → `dotnet new cwconsole` → build → run) on ARM64, so the template's cross-platform support is **verified on ARM64**, not just asserted. Existing x64 legs (ubuntu/windows/macos) are unchanged.

Low signal by nature — the generated app is pure managed .NET, so it's arch-invariant — but the runner is free and it's a ~4-line addition, so it's cheap insurance + a concrete proof-point.

**Verification note:** I can't run an ARM64 build locally (dev box is x64), so unlike the other CI changes this cycle, this leg's actual pass is confirmed by **this PR's own smoke-matrix run** — watch the `Template Smoke (ubuntu-24.04-arm, SDK 8.0)` check. YAML + actionlint + zizmor are clean. Base: `vNext`.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
