### PR TITLE
docs: set v0.6.0 CHANGELOG date to release day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.6.0] - 2026-07-12
+## [0.6.0] - 2026-07-13
 
 ### Added
 


### PR DESCRIPTION
One-line fix: the `[0.6.0]` CHANGELOG entry was dated 2026-07-12 (prep day); set it to the release day (2026-07-13) so it matches the `v0.6.0` tag. Merge before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)