### PR TITLE
docs(security): Release path & compromise scope appendix (#219)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,17 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/console-app-template`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: none internal — this is a `dotnet new` template pack, not a code dependency, so no Wolfgang.* repo consumes it. Consumers are developers who install the templates and generate projects; unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting**: this repo ships four packages —
+  - `Wolfgang.Template.Console` — https://www.nuget.org/packages/Wolfgang.Template.Console/
+  - `Wolfgang.Template.Console.Subcommand` — https://www.nuget.org/packages/Wolfgang.Template.Console.Subcommand/
+  - `Wolfgang.Template.Console.ETL-SubCommand` — https://www.nuget.org/packages/Wolfgang.Template.Console.ETL-SubCommand/
+  - `Wolfgang.Template.Console.Aot` — https://www.nuget.org/packages/Wolfgang.Template.Console.Aot/


### PR DESCRIPTION
Appends the **"Release path & compromise scope"** section to `SECURITY.md` — the load-bearing per-repo facts a maintainer would need if the release identity is compromised. Matches the canonical shape from [Etl-DbClient #240](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/240); generic incident-response steps are intentionally not duplicated.

All five bullets filled in for this repo:
- **Release path** — OIDC / Trusted Publishing via `NuGet/login@v1`, no long-lived key
- **Fallback** — none; OIDC identity `Chris-Wolfgang/console-app-template`
- **Owner** — @Chris-Wolfgang
- **Downstream consumers** — none internal (it's a `dotnet new` template pack, not a code dependency)
- **Package coordinates** — the four published package IDs with nuget.org links

Docs-only; no version bump, no template-content change (won't affect generated projects or the snapshot).

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)